### PR TITLE
Simplified supported variables and resolver types.

### DIFF
--- a/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
+++ b/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
@@ -167,6 +167,19 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 		RebuildList();
 	}
 
+	private static int FindTypeDropdownIndex(OptionButton dropdown, StatescriptVariableType variableType)
+	{
+		for (int i = 0; i < dropdown.ItemCount; i++)
+		{
+			if (dropdown.GetItemId(i) == (int)variableType)
+			{
+				return i;
+			}
+		}
+
+		return 0;
+	}
+
 	private static void UpdateVariableNameButtonAppearance(Button button, bool isSelected)
 	{
 		Color buttonColor = isSelected ? _highlightColor : _variableColor;
@@ -770,6 +783,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 				StatescriptVariableTypeConverter.GetDisplayName(variableType),
 				(int)variableType);
 		}
+
+		_newTypeDropdown.Selected = FindTypeDropdownIndex(_newTypeDropdown, StatescriptVariableType.Int);
 
 		typeRow.AddChild(_newTypeDropdown);
 

--- a/addons/forge/editor/statescript/StatescriptVariablePanel.cs
+++ b/addons/forge/editor/statescript/StatescriptVariablePanel.cs
@@ -206,6 +206,19 @@ internal sealed partial class StatescriptVariablePanel : VBoxContainer, ISeriali
 		}
 	}
 
+	private static int FindTypeDropdownIndex(OptionButton dropdown, StatescriptVariableType variableType)
+	{
+		for (int i = 0; i < dropdown.ItemCount; i++)
+		{
+			if (dropdown.GetItemId(i) == (int)variableType)
+			{
+				return i;
+			}
+		}
+
+		return 0;
+	}
+
 	private static void UpdateVariableNameButtonAppearance(Button button, bool isSelected)
 	{
 		Color buttonColor = isSelected ? _highlightColor : _variableColor;
@@ -466,10 +479,12 @@ internal sealed partial class StatescriptVariablePanel : VBoxContainer, ISeriali
 
 		for (int t = 0; t < allTypes.Length; t++)
 		{
-			_newTypeDropdown.AddItem(StatescriptVariableTypeConverter.GetDisplayName(allTypes[t]), t);
+			_newTypeDropdown.AddItem(
+				StatescriptVariableTypeConverter.GetDisplayName(allTypes[t]),
+				(int)allTypes[t]);
 		}
 
-		_newTypeDropdown.Selected = (int)StatescriptVariableType.Int;
+		_newTypeDropdown.Selected = FindTypeDropdownIndex(_newTypeDropdown, StatescriptVariableType.Int);
 		typeRow.AddChild(_newTypeDropdown);
 
 		var arrayRow = new HBoxContainer { SizeFlagsHorizontal = SizeFlags.ExpandFill };

--- a/addons/forge/editor/statescript/node_editors/DebugNodeEditor.cs
+++ b/addons/forge/editor/statescript/node_editors/DebugNodeEditor.cs
@@ -82,15 +82,15 @@ internal sealed partial class DebugNodeEditor : CustomNodeEditor
 			SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
 			CustomMinimumSize = new Vector2(80, 0),
 		};
-		AddTypeOption(_typeDropdown, StatescriptVariableType.Bool, "Bool");
-		AddTypeOption(_typeDropdown, StatescriptVariableType.Int, "Int");
-		AddTypeOption(_typeDropdown, StatescriptVariableType.Float, "Float");
-		AddTypeOption(_typeDropdown, StatescriptVariableType.Double, "Double");
-		AddTypeOption(_typeDropdown, StatescriptVariableType.Vector2, "Vector2");
-		AddTypeOption(_typeDropdown, StatescriptVariableType.Vector3, "Vector3");
-		AddTypeOption(_typeDropdown, StatescriptVariableType.Vector4, "Vector4");
-		AddTypeOption(_typeDropdown, StatescriptVariableType.Plane, "Plane");
-		AddTypeOption(_typeDropdown, StatescriptVariableType.Quaternion, "Quaternion");
+
+		foreach (StatescriptVariableType variableType in StatescriptVariableTypeConverter.GetAllTypes())
+		{
+			AddTypeOption(
+				_typeDropdown,
+				variableType,
+				StatescriptVariableTypeConverter.GetDisplayName(variableType));
+		}
+
 		_typeDropdown.Selected = FindSelectedTypeIndex(_typeDropdown);
 		_typeDropdown.ItemSelected += OnTypeDropdownItemSelected;
 		headerRow.AddChild(_typeDropdown);

--- a/addons/forge/editor/statescript/resolvers/ActivationDataResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/ActivationDataResolverEditor.cs
@@ -131,13 +131,7 @@ internal sealed partial class ActivationDataResolverEditor : NodeEditorProperty
 
 	private static bool IsCompatibleType(Type expectedType, StatescriptVariableType fieldType)
 	{
-		if (expectedType == typeof(Variant128))
-		{
-			return true;
-		}
-
-		Type actualType = StatescriptVariableTypeConverter.ToSystemType(fieldType);
-		return expectedType == actualType;
+		return StatescriptVariableTypeConverter.IsCompatible(expectedType, fieldType);
 	}
 
 	private static string FindExistingProvider(StatescriptGraph graph, StatescriptNodeProperty? currentProperty)

--- a/addons/forge/editor/statescript/resolvers/ClampMagnitudeResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/ClampMagnitudeResolverEditor.cs
@@ -22,7 +22,7 @@ internal sealed partial class ClampMagnitudeResolverEditor
 
 	protected override Type[] LeftFactoryExpectedTypes => [typeof(SysVector2), typeof(SysVector3), typeof(SysVector4)];
 
-	protected override Type[] RightFactoryExpectedTypes => [typeof(float), typeof(double)];
+	protected override Type[] RightFactoryExpectedTypes => ResolverEditorCompatibility.FloatOperandExpectedTypes;
 
 	protected override Type LeftNestedExpectedType => typeof(ForgeVariant128);
 

--- a/addons/forge/editor/statescript/resolvers/MoveTowardsResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/MoveTowardsResolverEditor.cs
@@ -20,13 +20,12 @@ internal sealed partial class MoveTowardsResolverEditor : TernaryNestedResolverE
 	public override string ResolverTypeId => "MoveTowards";
 
 	protected override Type[] FirstFactoryExpectedTypes =>
-		[typeof(float), typeof(double), typeof(SysVector2), typeof(SysVector3), typeof(SysVector4)];
+		[typeof(int), typeof(float), typeof(double), typeof(SysVector2), typeof(SysVector3), typeof(SysVector4)];
 
 	protected override Type[] SecondFactoryExpectedTypes =>
-		[typeof(float), typeof(double), typeof(SysVector2), typeof(SysVector3), typeof(SysVector4)];
+		[typeof(int), typeof(float), typeof(double), typeof(SysVector2), typeof(SysVector3), typeof(SysVector4)];
 
-	protected override Type[] ThirdFactoryExpectedTypes =>
-		[typeof(float), typeof(double)];
+	protected override Type[] ThirdFactoryExpectedTypes => ResolverEditorCompatibility.FloatOperandExpectedTypes;
 
 	protected override Type FirstNestedExpectedType => typeof(ForgeVariant128);
 
@@ -53,11 +52,11 @@ internal sealed partial class MoveTowardsResolverEditor : TernaryNestedResolverE
 	{
 		if (expectedType == typeof(float))
 		{
-			return [typeof(float), typeof(double)];
+			return ResolverEditorCompatibility.FloatOperandExpectedTypes;
 		}
 		else if (expectedType == typeof(ForgeVariant128))
 		{
-			return [typeof(float), typeof(double), typeof(SysVector2), typeof(SysVector3), typeof(SysVector4)];
+			return [typeof(int), typeof(float), typeof(double), typeof(SysVector2), typeof(SysVector3), typeof(SysVector4)];
 		}
 		else
 		{

--- a/addons/forge/editor/statescript/resolvers/PlaneFromNormalResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/PlaneFromNormalResolverEditor.cs
@@ -21,7 +21,7 @@ internal sealed partial class PlaneFromNormalResolverEditor
 
 	protected override Type[] LeftFactoryExpectedTypes => [typeof(SysVector3)];
 
-	protected override Type[] RightFactoryExpectedTypes => [typeof(float), typeof(double)];
+	protected override Type[] RightFactoryExpectedTypes => ResolverEditorCompatibility.FloatOperandExpectedTypes;
 
 	protected override Type LeftNestedExpectedType => typeof(SysVector3);
 

--- a/addons/forge/editor/statescript/resolvers/QuaternionFromAxisAngleResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/QuaternionFromAxisAngleResolverEditor.cs
@@ -21,7 +21,7 @@ internal sealed partial class QuaternionFromAxisAngleResolverEditor
 
 	protected override Type[] LeftFactoryExpectedTypes => [typeof(SysVector3)];
 
-	protected override Type[] RightFactoryExpectedTypes => [typeof(float), typeof(double)];
+	protected override Type[] RightFactoryExpectedTypes => ResolverEditorCompatibility.FloatOperandExpectedTypes;
 
 	protected override Type LeftNestedExpectedType => typeof(SysVector3);
 

--- a/addons/forge/editor/statescript/resolvers/QuaternionFromYawPitchRollResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/QuaternionFromYawPitchRollResolverEditor.cs
@@ -18,11 +18,11 @@ internal sealed partial class QuaternionFromYawPitchRollResolverEditor
 
 	public override string ResolverTypeId => "QuaternionFromYawPitchRoll";
 
-	protected override Type[] FirstFactoryExpectedTypes => [typeof(float), typeof(double)];
+	protected override Type[] FirstFactoryExpectedTypes => ResolverEditorCompatibility.FloatOperandExpectedTypes;
 
-	protected override Type[] SecondFactoryExpectedTypes => [typeof(float), typeof(double)];
+	protected override Type[] SecondFactoryExpectedTypes => ResolverEditorCompatibility.FloatOperandExpectedTypes;
 
-	protected override Type[] ThirdFactoryExpectedTypes => [typeof(float), typeof(double)];
+	protected override Type[] ThirdFactoryExpectedTypes => ResolverEditorCompatibility.FloatOperandExpectedTypes;
 
 	protected override Type FirstNestedExpectedType => typeof(float);
 

--- a/addons/forge/editor/statescript/resolvers/RandomResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/RandomResolverEditor.cs
@@ -89,7 +89,6 @@ internal sealed partial class RandomResolverEditor : NodeEditorProperty
 			_typeDropdown = new OptionButton { SizeFlagsHorizontal = SizeFlags.ExpandFill };
 			_typeDropdown.AddItem("Int");
 			_typeDropdown.AddItem("Float");
-			_typeDropdown.AddItem("Double");
 			_typeDropdown.Selected = GetTypeDropdownIndex(_valueType);
 			_typeDropdown.ItemSelected += OnTypeDropdownItemSelected;
 			typeRow.AddChild(_typeDropdown);
@@ -205,7 +204,7 @@ internal sealed partial class RandomResolverEditor : NodeEditorProperty
 	{
 		return valueType switch
 		{
-			StatescriptVariableType.Float => typeof(float),
+			StatescriptVariableType.Float => typeof(double),
 			StatescriptVariableType.Double => typeof(double),
 			_ => typeof(int),
 		};
@@ -213,12 +212,12 @@ internal sealed partial class RandomResolverEditor : NodeEditorProperty
 
 	private static StatescriptVariableType GetDefaultValueType(Type expectedType)
 	{
-		if (expectedType == typeof(float))
+		if (expectedType == typeof(double))
 		{
-			return StatescriptVariableType.Float;
+			return StatescriptVariableType.Double;
 		}
 
-		if (expectedType == typeof(double))
+		if (expectedType == typeof(float))
 		{
 			return StatescriptVariableType.Double;
 		}
@@ -231,7 +230,7 @@ internal sealed partial class RandomResolverEditor : NodeEditorProperty
 		return valueType switch
 		{
 			StatescriptVariableType.Float => 1,
-			StatescriptVariableType.Double => 2,
+			StatescriptVariableType.Double => 1,
 			_ => 0,
 		};
 	}
@@ -274,8 +273,7 @@ internal sealed partial class RandomResolverEditor : NodeEditorProperty
 	{
 		_valueType = index switch
 		{
-			1 => StatescriptVariableType.Float,
-			2 => StatescriptVariableType.Double,
+			1 => StatescriptVariableType.Double,
 			_ => StatescriptVariableType.Int,
 		};
 

--- a/addons/forge/editor/statescript/resolvers/RotateTowardsResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/RotateTowardsResolverEditor.cs
@@ -22,7 +22,7 @@ internal sealed partial class RotateTowardsResolverEditor
 
 	protected override Type[] SecondFactoryExpectedTypes => [typeof(SysQuaternion)];
 
-	protected override Type[] ThirdFactoryExpectedTypes => [typeof(float), typeof(double)];
+	protected override Type[] ThirdFactoryExpectedTypes => ResolverEditorCompatibility.FloatOperandExpectedTypes;
 
 	protected override Type FirstNestedExpectedType => typeof(SysQuaternion);
 

--- a/addons/forge/editor/statescript/resolvers/RoundResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/RoundResolverEditor.cs
@@ -45,7 +45,8 @@ internal sealed partial class RoundResolverEditor : NodeEditorProperty
 	{
 		_graph = graph;
 		_onChanged = onChanged;
-		_operandFactories = ResolverEditorFactoryCatalog.GetCompatibleFactories(typeof(float), typeof(double));
+		_operandFactories = ResolverEditorFactoryCatalog.GetCompatibleFactories(
+			ResolverEditorCompatibility.FloatOperandExpectedTypes);
 		var existing = property?.Resolver as RoundResolverResource;
 		_digits = existing?.Digits ?? 0;
 		_mode = existing?.Mode ?? MidpointRounding.ToEven;

--- a/addons/forge/editor/statescript/resolvers/SlerpResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/SlerpResolverEditor.cs
@@ -21,7 +21,7 @@ internal sealed partial class SlerpResolverEditor : TernaryNestedResolverEditorB
 
 	protected override Type[] SecondFactoryExpectedTypes => [typeof(SysQuaternion)];
 
-	protected override Type[] ThirdFactoryExpectedTypes => [typeof(float), typeof(double)];
+	protected override Type[] ThirdFactoryExpectedTypes => ResolverEditorCompatibility.FloatOperandExpectedTypes;
 
 	protected override Type FirstNestedExpectedType => typeof(SysQuaternion);
 

--- a/addons/forge/editor/statescript/resolvers/VariantResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/VariantResolverEditor.cs
@@ -7,6 +7,7 @@ using Gamesmiths.Forge.Godot.Resources.Statescript;
 using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
 using Godot;
 using Godot.Collections;
+using ForgeVariant128 = Gamesmiths.Forge.Statescript.Variant128;
 using GodotVariant = Godot.Variant;
 using GodotVector2 = Godot.Vector2;
 
@@ -459,6 +460,15 @@ internal sealed partial class VariantResolverEditor : NodeEditorProperty
 	private StatescriptVariableType[] ResolveAllowedValueTypes(Type expectedType)
 	{
 		Type[] allowedExpectedTypes = GetAllowedExpectedTypes(expectedType);
+
+		for (int i = 0; i < allowedExpectedTypes.Length; i++)
+		{
+			if (allowedExpectedTypes[i] == typeof(ForgeVariant128))
+			{
+				return StatescriptVariableTypeConverter.GetAllTypes();
+			}
+		}
+
 		var result = new List<StatescriptVariableType>();
 
 		for (int i = 0; i < allowedExpectedTypes.Length; i++)
@@ -477,6 +487,11 @@ internal sealed partial class VariantResolverEditor : NodeEditorProperty
 
 	private StatescriptVariableType GetDefaultValueType(Type expectedType)
 	{
+		if (expectedType == typeof(ForgeVariant128))
+		{
+			return StatescriptVariableType.Int;
+		}
+
 		if (_allowedValueTypes.Length > 0)
 		{
 			return _allowedValueTypes[0];

--- a/addons/forge/editor/statescript/resolvers/VectorFromValuesResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/VectorFromValuesResolverEditor.cs
@@ -67,7 +67,8 @@ internal sealed partial class VectorFromValuesResolverEditor : NodeEditorPropert
 		_graph = graph;
 		_onChanged = onChanged;
 		_valueType = ResolveValueType(property, expectedType);
-		_factories = ResolverEditorFactoryCatalog.GetCompatibleFactories(typeof(float), typeof(double));
+		_factories = ResolverEditorFactoryCatalog.GetCompatibleFactories(
+			ResolverEditorCompatibility.FloatOperandExpectedTypes);
 
 		SizeFlagsHorizontal = SizeFlags.ExpandFill;
 		var root = new VBoxContainer { SizeFlagsHorizontal = SizeFlags.ExpandFill };
@@ -340,7 +341,7 @@ internal sealed partial class VectorFromValuesResolverEditor : NodeEditorPropert
 			_factories,
 			factoryIndex,
 			existingResolver,
-			[typeof(float), typeof(double)],
+			ResolverEditorCompatibility.FloatOperandExpectedTypes,
 			OnNestedEditorChanged,
 			RaiseLayoutSizeChanged);
 

--- a/addons/forge/editor/statescript/resolvers/bases/FloatUnaryResolverEditorBase.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/FloatUnaryResolverEditorBase.cs
@@ -10,7 +10,7 @@ namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers.Bases;
 internal abstract partial class FloatUnaryResolverEditorBase<TResource> : UnaryNestedResolverEditorBase<TResource>
 	where TResource : UnaryNestedResolverResourceBase, new()
 {
-	protected override Type[] FactoryExpectedTypes => [typeof(float), typeof(double)];
+	protected override Type[] FactoryExpectedTypes => ResolverEditorCompatibility.FloatOperandExpectedTypes;
 
 	protected override Type NestedExpectedType => typeof(float);
 

--- a/addons/forge/editor/statescript/resolvers/bases/NestedResolverEditorUtilities.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/NestedResolverEditorUtilities.cs
@@ -146,11 +146,7 @@ internal static class NestedResolverEditorUtilities
 
 	private static bool AreExpectedTypesCompatible(Type candidateExpectedType, Type allowedExpectedType)
 	{
-		return candidateExpectedType == allowedExpectedType
-			|| candidateExpectedType == typeof(ForgeVariant128)
-			|| allowedExpectedType == typeof(ForgeVariant128)
-			|| (ResolverEditorCompatibility.IsFloatType(candidateExpectedType)
-				&& ResolverEditorCompatibility.IsFloatType(allowedExpectedType));
+		return ResolverEditorCompatibility.AreExpectedTypesCompatible(candidateExpectedType, allowedExpectedType);
 	}
 
 	private static bool ContainsVariantType(Type[] expectedTypes)

--- a/addons/forge/editor/statescript/resolvers/bases/ResolverEditorCompatibility.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/ResolverEditorCompatibility.cs
@@ -3,6 +3,7 @@
 #if TOOLS
 using System;
 using Gamesmiths.Forge.Godot.Resources.Statescript;
+using ForgeVariant128 = Gamesmiths.Forge.Statescript.Variant128;
 using SysPlane = System.Numerics.Plane;
 using SysQuaternion = System.Numerics.Quaternion;
 using SysVector2 = System.Numerics.Vector2;
@@ -13,6 +14,8 @@ namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers.Bases;
 
 internal static class ResolverEditorCompatibility
 {
+	public static readonly Type[] FloatOperandExpectedTypes = [typeof(int), typeof(float), typeof(double)];
+
 	public static bool IsNumericType(Type expectedType)
 	{
 		if (!StatescriptVariableTypeConverter.TryFromSystemType(expectedType, out StatescriptVariableType variableType))
@@ -64,6 +67,14 @@ internal static class ResolverEditorCompatibility
 	public static bool IsNumericVectorOrQuaternionType(Type expectedType)
 	{
 		return IsNumericOrVectorType(expectedType) || IsQuaternionType(expectedType);
+	}
+
+	public static bool AreExpectedTypesCompatible(Type candidateExpectedType, Type allowedExpectedType)
+	{
+		return candidateExpectedType == allowedExpectedType
+			|| candidateExpectedType == typeof(ForgeVariant128)
+			|| allowedExpectedType == typeof(ForgeVariant128)
+			|| StatescriptVariableTypeConverter.IsCompatible(allowedExpectedType, candidateExpectedType);
 	}
 }
 #endif

--- a/addons/forge/editor/statescript/resolvers/bases/ScalarBinaryResolverEditorBase.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/ScalarBinaryResolverEditorBase.cs
@@ -10,7 +10,7 @@ namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers.Bases;
 internal abstract partial class ScalarBinaryResolverEditorBase<TResource> : BinaryNestedResolverEditorBase<TResource>
 	where TResource : BinaryNestedResolverResourceBase, new()
 {
-	protected override Type[] FactoryExpectedTypes => [typeof(float), typeof(double)];
+	protected override Type[] FactoryExpectedTypes => ResolverEditorCompatibility.FloatOperandExpectedTypes;
 
 	protected override Type NestedExpectedType => typeof(float);
 

--- a/addons/forge/editor/statescript/resolvers/bases/ScalarConstantResolverEditorBase.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/ScalarConstantResolverEditorBase.cs
@@ -13,7 +13,6 @@ internal abstract partial class ScalarConstantResolverEditorBase<TResource> : No
 	where TResource : TypedConstantResolverResourceBase, new()
 {
 	private StatescriptVariableType _valueType;
-	private bool _allowTypeSelection;
 
 	public override bool IsCompatibleWith(Type expectedType)
 	{
@@ -29,26 +28,13 @@ internal abstract partial class ScalarConstantResolverEditorBase<TResource> : No
 		Action onChanged,
 		bool isArray)
 	{
-		if (property?.Resolver is TResource existing)
+		if (property?.Resolver is TResource)
 		{
-			_valueType = NormalizeValueType(existing.ValueType);
-		}
-		else if (expectedType == typeof(double))
-		{
-			_valueType = StatescriptVariableType.Double;
+			_valueType = NormalizeValueType();
 		}
 		else
 		{
-			_valueType = StatescriptVariableType.Float;
-		}
-
-		_allowTypeSelection = expectedType == typeof(ForgeVariant128);
-
-		if (!_allowTypeSelection)
-		{
-			_valueType = expectedType == typeof(double)
-				? StatescriptVariableType.Double
-				: StatescriptVariableType.Float;
+			_valueType = StatescriptVariableType.Double;
 		}
 
 		SizeFlagsHorizontal = SizeFlags.ExpandFill;
@@ -62,23 +48,11 @@ internal abstract partial class ScalarConstantResolverEditorBase<TResource> : No
 			HorizontalAlignment = HorizontalAlignment.Right,
 		});
 
-		if (_allowTypeSelection)
+		row.AddChild(new Label
 		{
-			var typeDropdown = new OptionButton { SizeFlagsHorizontal = SizeFlags.ExpandFill };
-			typeDropdown.AddItem("Float");
-			typeDropdown.AddItem("Double");
-			typeDropdown.Selected = _valueType == StatescriptVariableType.Double ? 1 : 0;
-			typeDropdown.ItemSelected += OnTypeDropdownItemSelected;
-			row.AddChild(typeDropdown);
-		}
-		else
-		{
-			row.AddChild(new Label
-			{
-				Text = _valueType == StatescriptVariableType.Double ? "Double" : "Float",
-				SizeFlagsHorizontal = SizeFlags.ExpandFill,
-			});
-		}
+			Text = "Float",
+			SizeFlagsHorizontal = SizeFlags.ExpandFill,
+		});
 	}
 
 	public override void SaveTo(StatescriptNodeProperty property)
@@ -86,16 +60,9 @@ internal abstract partial class ScalarConstantResolverEditorBase<TResource> : No
 		property.Resolver = new TResource { ValueType = _valueType };
 	}
 
-	private static StatescriptVariableType NormalizeValueType(StatescriptVariableType valueType)
+	private static StatescriptVariableType NormalizeValueType()
 	{
-		return valueType == StatescriptVariableType.Double
-			? StatescriptVariableType.Double
-			: StatescriptVariableType.Float;
-	}
-
-	private void OnTypeDropdownItemSelected(long index)
-	{
-		_valueType = index == 1 ? StatescriptVariableType.Double : StatescriptVariableType.Float;
+		return StatescriptVariableType.Double;
 	}
 }
 #endif

--- a/addons/forge/editor/statescript/resolvers/bases/ScalarUnaryResolverEditorBase.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/ScalarUnaryResolverEditorBase.cs
@@ -10,7 +10,7 @@ namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers.Bases;
 internal abstract partial class ScalarUnaryResolverEditorBase<TResource> : UnaryNestedResolverEditorBase<TResource>
 	where TResource : UnaryNestedResolverResourceBase, new()
 {
-	protected override Type[] FactoryExpectedTypes => [typeof(float), typeof(double)];
+	protected override Type[] FactoryExpectedTypes => ResolverEditorCompatibility.FloatOperandExpectedTypes;
 
 	protected override Type NestedExpectedType => typeof(float);
 

--- a/addons/forge/editor/statescript/resolvers/bases/ScaleResolverEditorBase.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/ScaleResolverEditorBase.cs
@@ -15,7 +15,7 @@ internal abstract partial class ScaleResolverEditorBase<TResource> : AsymmetricB
 {
 	protected override Type[] LeftFactoryExpectedTypes => [typeof(SysVector2), typeof(SysVector3), typeof(SysVector4)];
 
-	protected override Type[] RightFactoryExpectedTypes => [typeof(float), typeof(double)];
+	protected override Type[] RightFactoryExpectedTypes => ResolverEditorCompatibility.FloatOperandExpectedTypes;
 
 	protected override Type LeftNestedExpectedType => typeof(ForgeVariant128);
 

--- a/addons/forge/resources/statescript/NumericCoercionResolver.cs
+++ b/addons/forge/resources/statescript/NumericCoercionResolver.cs
@@ -1,0 +1,20 @@
+// Copyright © Gamesmiths Guild.
+
+using System;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Godot.Resources.Statescript;
+
+internal sealed class NumericCoercionResolver(IPropertyResolver innerResolver, Type targetType) : IPropertyResolver
+{
+	private readonly IPropertyResolver _innerResolver = innerResolver;
+
+	public Type ValueType { get; } = targetType;
+
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		Variant128 sourceValue = _innerResolver.Resolve(graphContext);
+		return StatescriptNumericCompatibility.Coerce(sourceValue, _innerResolver.ValueType, ValueType);
+	}
+}

--- a/addons/forge/resources/statescript/NumericCoercionResolver.cs.uid
+++ b/addons/forge/resources/statescript/NumericCoercionResolver.cs.uid
@@ -1,0 +1,1 @@
+uid://b21gkd4yj5xqm

--- a/addons/forge/resources/statescript/StatescriptNumericCompatibility.cs
+++ b/addons/forge/resources/statescript/StatescriptNumericCompatibility.cs
@@ -1,0 +1,171 @@
+// Copyright © Gamesmiths Guild.
+
+using System;
+using System.Globalization;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+
+namespace Gamesmiths.Forge.Godot.Resources.Statescript;
+
+internal static class StatescriptNumericCompatibility
+{
+	public static bool CanCoerce(Type sourceType, Type targetType)
+	{
+		if (sourceType == targetType)
+		{
+			return true;
+		}
+
+		if (!IsNumericType(sourceType) || !IsNumericType(targetType))
+		{
+			return false;
+		}
+
+		if (IsIntegralType(targetType))
+		{
+			return IsIntegralType(sourceType);
+		}
+
+		return IsFloatingPointType(targetType);
+	}
+
+	public static Variant128 Coerce(Variant128 value, Type sourceType, Type targetType)
+	{
+		if (!CanCoerce(sourceType, targetType))
+		{
+			throw new InvalidOperationException(
+				$"Cannot coerce Statescript numeric value from '{sourceType}' to '{targetType}'.");
+		}
+
+		object numericValue = GetNumericValue(sourceType, value);
+		return targetType switch
+		{
+			_ when targetType == typeof(byte) => new Variant128(
+				Convert.ToByte(numericValue, CultureInfo.InvariantCulture)),
+			_ when targetType == typeof(sbyte) => new Variant128(
+				Convert.ToSByte(numericValue, CultureInfo.InvariantCulture)),
+			_ when targetType == typeof(char) => new Variant128(
+				Convert.ToChar(numericValue, CultureInfo.InvariantCulture)),
+			_ when targetType == typeof(short) => new Variant128(
+				Convert.ToInt16(numericValue, CultureInfo.InvariantCulture)),
+			_ when targetType == typeof(ushort) => new Variant128(
+				Convert.ToUInt16(numericValue, CultureInfo.InvariantCulture)),
+			_ when targetType == typeof(int) => new Variant128(
+				Convert.ToInt32(numericValue, CultureInfo.InvariantCulture)),
+			_ when targetType == typeof(uint) => new Variant128(
+				Convert.ToUInt32(numericValue, CultureInfo.InvariantCulture)),
+			_ when targetType == typeof(long) => new Variant128(
+				Convert.ToInt64(numericValue, CultureInfo.InvariantCulture)),
+			_ when targetType == typeof(ulong) => new Variant128(
+				Convert.ToUInt64(numericValue, CultureInfo.InvariantCulture)),
+			_ when targetType == typeof(float) => new Variant128(
+				Convert.ToSingle(numericValue, CultureInfo.InvariantCulture)),
+			_ when targetType == typeof(double) => new Variant128(
+				Convert.ToDouble(numericValue, CultureInfo.InvariantCulture)),
+			_ when targetType == typeof(decimal) => new Variant128(
+				Convert.ToDecimal(numericValue, CultureInfo.InvariantCulture)),
+			_ => throw new InvalidOperationException(
+				$"Cannot coerce Statescript numeric value to unsupported target type '{targetType}'."),
+		};
+	}
+
+	public static bool IsNumericType(Type type)
+	{
+		return type == typeof(byte)
+			|| type == typeof(sbyte)
+			|| type == typeof(char)
+			|| type == typeof(short)
+			|| type == typeof(ushort)
+			|| type == typeof(int)
+			|| type == typeof(uint)
+			|| type == typeof(long)
+			|| type == typeof(ulong)
+			|| type == typeof(float)
+			|| type == typeof(double)
+			|| type == typeof(decimal);
+	}
+
+	private static bool IsFloatingPointType(Type type)
+	{
+		return type == typeof(float) || type == typeof(double) || type == typeof(decimal);
+	}
+
+	private static bool IsIntegralType(Type type)
+	{
+		return type == typeof(byte)
+			|| type == typeof(sbyte)
+			|| type == typeof(char)
+			|| type == typeof(short)
+			|| type == typeof(ushort)
+			|| type == typeof(int)
+			|| type == typeof(uint)
+			|| type == typeof(long)
+			|| type == typeof(ulong);
+	}
+
+	private static object GetNumericValue(Type type, Variant128 value)
+	{
+		if (type == typeof(byte))
+		{
+			return value.AsByte();
+		}
+
+		if (type == typeof(sbyte))
+		{
+			return value.AsSByte();
+		}
+
+		if (type == typeof(char))
+		{
+			return value.AsChar();
+		}
+
+		if (type == typeof(short))
+		{
+			return value.AsShort();
+		}
+
+		if (type == typeof(ushort))
+		{
+			return value.AsUShort();
+		}
+
+		if (type == typeof(int))
+		{
+			return value.AsInt();
+		}
+
+		if (type == typeof(uint))
+		{
+			return value.AsUInt();
+		}
+
+		if (type == typeof(long))
+		{
+			return value.AsLong();
+		}
+
+		if (type == typeof(ulong))
+		{
+			return value.AsULong();
+		}
+
+		if (type == typeof(float))
+		{
+			return value.AsFloat();
+		}
+
+		if (type == typeof(double))
+		{
+			return value.AsDouble();
+		}
+
+		if (type == typeof(decimal))
+		{
+			return value.AsDecimal();
+		}
+
+		throw new InvalidOperationException(
+			$"Cannot read Statescript numeric value from unsupported source type '{type}'.");
+	}
+}

--- a/addons/forge/resources/statescript/StatescriptNumericCompatibility.cs.uid
+++ b/addons/forge/resources/statescript/StatescriptNumericCompatibility.cs.uid
@@ -1,0 +1,1 @@
+uid://bmmwqoyo6m0y8

--- a/addons/forge/resources/statescript/StatescriptResolverResource.cs
+++ b/addons/forge/resources/statescript/StatescriptResolverResource.cs
@@ -1,5 +1,7 @@
 // Copyright © Gamesmiths Guild.
 
+using System;
+using System.Linq;
 using Gamesmiths.Forge.Core;
 using Gamesmiths.Forge.Statescript;
 using Gamesmiths.Forge.Statescript.Properties;
@@ -61,5 +63,113 @@ public partial class StatescriptResolverResource : Resource
 	public virtual IPropertyResolver BuildResolver(Graph graph)
 	{
 		return new VariantResolver(default, typeof(int));
+	}
+
+	protected static void DefineAndBindInputProperty(
+		Graph graph,
+		ForgeNode runtimeNode,
+		string propertyName,
+		byte index,
+		IPropertyResolver resolver)
+	{
+		var propertyKey = new StringKey(propertyName);
+		graph.VariableDefinitions.DefineProperty(
+			propertyKey,
+			AdaptResolverForExpectedInput(runtimeNode, index, resolver));
+		runtimeNode.BindInput(index, propertyKey);
+	}
+
+	protected static bool NeedsNumericInputAdaptation(
+		ForgeNode runtimeNode,
+		byte index,
+		Type actualType)
+	{
+		if (index >= runtimeNode.InputProperties.Length)
+		{
+			return false;
+		}
+
+		Type expectedType = runtimeNode.InputProperties[index].ExpectedType;
+		return expectedType != typeof(Variant128)
+			&& expectedType != actualType
+			&& StatescriptNumericCompatibility.CanCoerce(actualType, expectedType);
+	}
+
+	protected static IPropertyResolver AdaptResolverForExpectedType(
+		IPropertyResolver resolver,
+		Type expectedType)
+	{
+		if (expectedType == typeof(Variant128) || expectedType == resolver.ValueType)
+		{
+			return resolver;
+		}
+
+		if (StatescriptNumericCompatibility.CanCoerce(resolver.ValueType, expectedType))
+		{
+			return new NumericCoercionResolver(resolver, expectedType);
+		}
+
+		return resolver;
+	}
+
+	protected static IPropertyResolver PromoteIntegralResolverToFloatingPoint(
+		IPropertyResolver resolver,
+		Type preferredFloatingType)
+	{
+		if (!StatescriptNumericCompatibility.IsNumericType(resolver.ValueType)
+			|| IsFloatingPointType(resolver.ValueType))
+		{
+			return resolver;
+		}
+
+		return AdaptResolverForExpectedType(resolver, preferredFloatingType);
+	}
+
+	protected static Type GetPreferredFloatingPointType(params IPropertyResolver[] resolvers)
+	{
+		foreach (Type resolverType in resolvers.Select(resolver => resolver.ValueType))
+		{
+			if (resolverType == typeof(double) || resolverType == typeof(decimal))
+			{
+				return typeof(double);
+			}
+		}
+
+		foreach (IPropertyResolver resolver in resolvers)
+		{
+			if (resolver.ValueType == typeof(float))
+			{
+				return typeof(float);
+			}
+		}
+
+		return typeof(double);
+	}
+
+	protected static bool IsVectorOrQuaternionType(Type type)
+	{
+		return type == typeof(System.Numerics.Vector2)
+			|| type == typeof(System.Numerics.Vector3)
+			|| type == typeof(System.Numerics.Vector4)
+			|| type == typeof(System.Numerics.Quaternion);
+	}
+
+	private static IPropertyResolver AdaptResolverForExpectedInput(
+		ForgeNode runtimeNode,
+		byte index,
+		IPropertyResolver resolver)
+	{
+		if (index >= runtimeNode.InputProperties.Length)
+		{
+			return resolver;
+		}
+
+		Type expectedType = runtimeNode.InputProperties[index].ExpectedType;
+		return AdaptResolverForExpectedType(resolver, expectedType);
+	}
+
+	private static bool IsFloatingPointType(Type type)
+	{
+		return type == typeof(float) || type == typeof(double) || type == typeof(decimal);
 	}
 }

--- a/addons/forge/resources/statescript/StatescriptVariableTypeConverter.cs
+++ b/addons/forge/resources/statescript/StatescriptVariableTypeConverter.cs
@@ -21,6 +21,18 @@ namespace Gamesmiths.Forge.Godot.Resources.Statescript;
 /// </summary>
 public static class StatescriptVariableTypeConverter
 {
+	private static readonly StatescriptVariableType[] _authoringTypes =
+	[
+		StatescriptVariableType.Bool,
+		StatescriptVariableType.Int,
+		StatescriptVariableType.Double,
+		StatescriptVariableType.Vector2,
+		StatescriptVariableType.Vector3,
+		StatescriptVariableType.Vector4,
+		StatescriptVariableType.Plane,
+		StatescriptVariableType.Quaternion,
+	];
+
 	private static readonly Dictionary<StatescriptVariableType, Type> _typeMap = new()
 	{
 		[StatescriptVariableType.Bool] = typeof(bool),
@@ -43,15 +55,27 @@ public static class StatescriptVariableTypeConverter
 		[StatescriptVariableType.Quaternion] = typeof(System.Numerics.Quaternion),
 	};
 
-	private static readonly Dictionary<Type, StatescriptVariableType> _reverseTypeMap = [];
-
-	static StatescriptVariableTypeConverter()
+	private static readonly Dictionary<Type, StatescriptVariableType> _authoringTypeMap = new()
 	{
-		foreach (KeyValuePair<StatescriptVariableType, Type> kvp in _typeMap)
-		{
-			_reverseTypeMap[kvp.Value] = kvp.Key;
-		}
-	}
+		[typeof(bool)] = StatescriptVariableType.Bool,
+		[typeof(byte)] = StatescriptVariableType.Int,
+		[typeof(sbyte)] = StatescriptVariableType.Int,
+		[typeof(char)] = StatescriptVariableType.Int,
+		[typeof(short)] = StatescriptVariableType.Int,
+		[typeof(ushort)] = StatescriptVariableType.Int,
+		[typeof(int)] = StatescriptVariableType.Int,
+		[typeof(uint)] = StatescriptVariableType.Int,
+		[typeof(long)] = StatescriptVariableType.Int,
+		[typeof(ulong)] = StatescriptVariableType.Int,
+		[typeof(float)] = StatescriptVariableType.Double,
+		[typeof(double)] = StatescriptVariableType.Double,
+		[typeof(decimal)] = StatescriptVariableType.Double,
+		[typeof(SysVector2)] = StatescriptVariableType.Vector2,
+		[typeof(SysVector3)] = StatescriptVariableType.Vector3,
+		[typeof(SysVector4)] = StatescriptVariableType.Vector4,
+		[typeof(System.Numerics.Plane)] = StatescriptVariableType.Plane,
+		[typeof(System.Numerics.Quaternion)] = StatescriptVariableType.Quaternion,
+	};
 
 	/// <summary>
 	/// Gets all supported variable type values.
@@ -59,7 +83,7 @@ public static class StatescriptVariableTypeConverter
 	/// <returns>All values of <see cref="StatescriptVariableType"/>.</returns>
 	public static StatescriptVariableType[] GetAllTypes()
 	{
-		return (StatescriptVariableType[])Enum.GetValues(typeof(StatescriptVariableType));
+		return [.. _authoringTypes];
 	}
 
 	/// <summary>
@@ -80,7 +104,7 @@ public static class StatescriptVariableTypeConverter
 	/// <returns><see langword="true"/> if a matching variable type was found.</returns>
 	public static bool TryFromSystemType(Type type, out StatescriptVariableType variableType)
 	{
-		return _reverseTypeMap.TryGetValue(type, out variableType);
+		return _authoringTypeMap.TryGetValue(type, out variableType);
 	}
 
 	/// <summary>
@@ -95,20 +119,8 @@ public static class StatescriptVariableTypeConverter
 	/// <returns><see langword="true"/> if the types are compatible.</returns>
 	public static bool IsCompatible(Type expectedType, StatescriptVariableType variableType)
 	{
-		if (expectedType == typeof(Variant128))
-		{
-			return true;
-		}
-
 		Type actualType = ToSystemType(variableType);
-
-		if ((expectedType == typeof(float) && actualType == typeof(double))
-			|| (expectedType == typeof(double) && actualType == typeof(float)))
-		{
-			return true;
-		}
-
-		return expectedType == actualType;
+		return IsCompatible(expectedType, actualType);
 	}
 
 	/// <summary>
@@ -181,7 +193,33 @@ public static class StatescriptVariableTypeConverter
 	/// <returns>A human-readable name for the type.</returns>
 	public static string GetDisplayName(StatescriptVariableType variableType)
 	{
-		return variableType.ToString();
+		return variableType switch
+		{
+			StatescriptVariableType.Byte => "Int",
+			StatescriptVariableType.SByte => "Int",
+			StatescriptVariableType.Char => "Int",
+			StatescriptVariableType.Int => "Int",
+			StatescriptVariableType.UInt => "Int",
+			StatescriptVariableType.Long => "Int",
+			StatescriptVariableType.ULong => "Int",
+			StatescriptVariableType.Short => "Int",
+			StatescriptVariableType.UShort => "Int",
+			StatescriptVariableType.Decimal => "Float",
+			StatescriptVariableType.Double => "Float",
+			StatescriptVariableType.Float => "Float",
+			_ => variableType.ToString(),
+		};
+	}
+
+	internal static bool IsCompatible(Type expectedType, Type actualType)
+	{
+		if (expectedType == typeof(Variant128))
+		{
+			return true;
+		}
+
+		return expectedType == actualType
+			|| StatescriptNumericCompatibility.CanCoerce(actualType, expectedType);
 	}
 
 	private static Variant128 ToForgeVector2(GodotVector2 v)

--- a/addons/forge/resources/statescript/StatescriptVariableTypeConverter.cs
+++ b/addons/forge/resources/statescript/StatescriptVariableTypeConverter.cs
@@ -78,9 +78,10 @@ public static class StatescriptVariableTypeConverter
 	};
 
 	/// <summary>
-	/// Gets all supported variable type values.
+	/// Gets all supported designer-facing authoring types.
 	/// </summary>
-	/// <returns>All values of <see cref="StatescriptVariableType"/>.</returns>
+	/// <returns>The subset of <see cref="StatescriptVariableType"/> values exposed for authoring in the Godot editor.
+	/// </returns>
 	public static StatescriptVariableType[] GetAllTypes()
 	{
 		return [.. _authoringTypes];
@@ -111,8 +112,11 @@ public static class StatescriptVariableTypeConverter
 	/// Checks whether the given <see cref="Type"/> is compatible with the specified variable type.
 	/// </summary>
 	/// <remarks>
-	/// For <see cref="Variant128"/> (wildcard type), all types are compatible. Otherwise, strict type matching is used
-	/// with no implicit numeric conversions.
+	/// For <see cref="Variant128"/> (wildcard type), all types are compatible. Otherwise, exact type matches are
+	/// accepted, and numeric types are also considered compatible when
+	/// <see cref="StatescriptNumericCompatibility.CanCoerce(Type, Type)"/> can adapt the authored value to the expected
+	/// runtime type. This allows integral-to-integral and numeric-to-floating-point compatibility, but not
+	/// floating-point-to-integral coercion.
 	/// </remarks>
 	/// <param name="expectedType">The expected type from the node declaration.</param>
 	/// <param name="variableType">The variable type to check.</param>

--- a/addons/forge/resources/statescript/resolvers/ActivationDataResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/ActivationDataResolverResource.cs
@@ -84,6 +84,17 @@ public partial class ActivationDataResolverResource : StatescriptResolverResourc
 				new VariableDefinition(variableName, default, clrType));
 		}
 
+		if (NeedsNumericInputAdaptation(runtimeNode, index, clrType))
+		{
+			DefineAndBindInputProperty(
+				graph,
+				runtimeNode,
+				$"__activation_{nodeId}_{index}",
+				index,
+				new VariableResolver(variableName, clrType));
+			return;
+		}
+
 		runtimeNode.BindInput(index, variableName);
 	}
 

--- a/addons/forge/resources/statescript/resolvers/CeilResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/CeilResolverResource.cs
@@ -17,6 +17,9 @@ public partial class CeilResolverResource : UnaryNestedResolverResourceBase
 
 	protected override IPropertyResolver CreateResolver(IPropertyResolver operandResolver, Graph graph)
 	{
+		operandResolver = PromoteIntegralResolverToFloatingPoint(
+			operandResolver,
+			GetPreferredFloatingPointType(operandResolver));
 		return new CeilResolver(operandResolver);
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/ClampMagnitudeResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/ClampMagnitudeResolverResource.cs
@@ -20,6 +20,7 @@ public partial class ClampMagnitudeResolverResource : BinaryNestedResolverResour
 		IPropertyResolver rightResolver,
 		Graph graph)
 	{
+		rightResolver = AdaptResolverForExpectedType(rightResolver, typeof(float));
 		return new ClampMagnitudeResolver(leftResolver, rightResolver);
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/FloorResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/FloorResolverResource.cs
@@ -17,6 +17,9 @@ public partial class FloorResolverResource : UnaryNestedResolverResourceBase
 
 	protected override IPropertyResolver CreateResolver(IPropertyResolver operandResolver, Graph graph)
 	{
+		operandResolver = PromoteIntegralResolverToFloatingPoint(
+			operandResolver,
+			GetPreferredFloatingPointType(operandResolver));
 		return new FloorResolver(operandResolver);
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/LerpResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/LerpResolverResource.cs
@@ -1,5 +1,6 @@
 // Copyright © Gamesmiths Guild.
 
+using System;
 using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers.Bases;
 using Gamesmiths.Forge.Statescript;
 using Gamesmiths.Forge.Statescript.Properties;
@@ -21,6 +22,18 @@ public partial class LerpResolverResource : TernaryNestedResolverResourceBase
 		IPropertyResolver thirdResolver,
 		Graph graph)
 	{
+		if (IsVectorOrQuaternionType(firstResolver.ValueType) || IsVectorOrQuaternionType(secondResolver.ValueType))
+		{
+			thirdResolver = AdaptResolverForExpectedType(thirdResolver, typeof(float));
+		}
+		else
+		{
+			Type preferredFloatingType = GetPreferredFloatingPointType(firstResolver, secondResolver, thirdResolver);
+			firstResolver = PromoteIntegralResolverToFloatingPoint(firstResolver, preferredFloatingType);
+			secondResolver = PromoteIntegralResolverToFloatingPoint(secondResolver, preferredFloatingType);
+			thirdResolver = PromoteIntegralResolverToFloatingPoint(thirdResolver, preferredFloatingType);
+		}
+
 		return new LerpResolver(firstResolver, secondResolver, thirdResolver);
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/MoveTowardsResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/MoveTowardsResolverResource.cs
@@ -21,6 +21,14 @@ public partial class MoveTowardsResolverResource : TernaryNestedResolverResource
 		IPropertyResolver thirdResolver,
 		Graph graph)
 	{
+		if (StatescriptNumericCompatibility.IsNumericType(firstResolver.ValueType)
+			&& StatescriptNumericCompatibility.IsNumericType(secondResolver.ValueType))
+		{
+			firstResolver = AdaptResolverForExpectedType(firstResolver, typeof(float));
+			secondResolver = AdaptResolverForExpectedType(secondResolver, typeof(float));
+		}
+
+		thirdResolver = AdaptResolverForExpectedType(thirdResolver, typeof(float));
 		return new MoveTowardsResolver(firstResolver, secondResolver, thirdResolver);
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/PlaneFromNormalResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/PlaneFromNormalResolverResource.cs
@@ -20,6 +20,7 @@ public partial class PlaneFromNormalResolverResource : BinaryNestedResolverResou
 		IPropertyResolver rightResolver,
 		Graph graph)
 	{
+		rightResolver = AdaptResolverForExpectedType(rightResolver, typeof(float));
 		return new PlaneFromNormalResolver(leftResolver, rightResolver);
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/QuaternionFromAxisAngleResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/QuaternionFromAxisAngleResolverResource.cs
@@ -20,6 +20,7 @@ public partial class QuaternionFromAxisAngleResolverResource : BinaryNestedResol
 		IPropertyResolver rightResolver,
 		Graph graph)
 	{
+		rightResolver = AdaptResolverForExpectedType(rightResolver, typeof(float));
 		return new QuaternionFromAxisAngleResolver(leftResolver, rightResolver);
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/QuaternionFromYawPitchRollResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/QuaternionFromYawPitchRollResolverResource.cs
@@ -21,6 +21,9 @@ public partial class QuaternionFromYawPitchRollResolverResource : TernaryNestedR
 		IPropertyResolver thirdResolver,
 		Graph graph)
 	{
+		firstResolver = AdaptResolverForExpectedType(firstResolver, typeof(float));
+		secondResolver = AdaptResolverForExpectedType(secondResolver, typeof(float));
+		thirdResolver = AdaptResolverForExpectedType(thirdResolver, typeof(float));
 		return new QuaternionFromYawPitchRollResolver(firstResolver, secondResolver, thirdResolver);
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/RotateTowardsResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/RotateTowardsResolverResource.cs
@@ -21,6 +21,7 @@ public partial class RotateTowardsResolverResource : TernaryNestedResolverResour
 		IPropertyResolver thirdResolver,
 		Graph graph)
 	{
+		thirdResolver = AdaptResolverForExpectedType(thirdResolver, typeof(float));
 		return new RotateTowardsResolver(firstResolver, secondResolver, thirdResolver);
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/RoundResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/RoundResolverResource.cs
@@ -24,6 +24,9 @@ public partial class RoundResolverResource : UnaryNestedResolverResourceBase
 
 	protected override IPropertyResolver CreateResolver(IPropertyResolver operandResolver, Graph graph)
 	{
+		operandResolver = PromoteIntegralResolverToFloatingPoint(
+			operandResolver,
+			GetPreferredFloatingPointType(operandResolver));
 		return new RoundResolver(operandResolver, Digits, Mode);
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/ScaleResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/ScaleResolverResource.cs
@@ -20,6 +20,7 @@ public partial class ScaleResolverResource : BinaryNestedResolverResourceBase
 		IPropertyResolver rightResolver,
 		Graph graph)
 	{
+		rightResolver = AdaptResolverForExpectedType(rightResolver, typeof(float));
 		return new ScaleResolver(leftResolver, rightResolver);
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/SharedVariableResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/SharedVariableResolverResource.cs
@@ -49,13 +49,12 @@ public partial class SharedVariableResolverResource : StatescriptResolverResourc
 		}
 
 		Type clrType = StatescriptVariableTypeConverter.ToSystemType(VariableType);
-		var propertyName = new StringKey($"__shared_{nodeId}_{index}");
-
-		graph.VariableDefinitions.DefineProperty(
-			propertyName,
+		DefineAndBindInputProperty(
+			graph,
+			runtimeNode,
+			$"__shared_{nodeId}_{index}",
+			index,
 			new SharedVariableResolver(new StringKey(VariableName), clrType));
-
-		runtimeNode.BindInput(index, propertyName);
 	}
 
 	/// <inheritdoc/>

--- a/addons/forge/resources/statescript/resolvers/SlerpResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/SlerpResolverResource.cs
@@ -21,6 +21,7 @@ public partial class SlerpResolverResource : TernaryNestedResolverResourceBase
 		IPropertyResolver thirdResolver,
 		Graph graph)
 	{
+		thirdResolver = AdaptResolverForExpectedType(thirdResolver, typeof(float));
 		return new SlerpResolver(firstResolver, secondResolver, thirdResolver);
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/TruncateResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/TruncateResolverResource.cs
@@ -17,6 +17,9 @@ public partial class TruncateResolverResource : UnaryNestedResolverResourceBase
 
 	protected override IPropertyResolver CreateResolver(IPropertyResolver operandResolver, Graph graph)
 	{
+		operandResolver = PromoteIntegralResolverToFloatingPoint(
+			operandResolver,
+			GetPreferredFloatingPointType(operandResolver));
 		return new TruncateResolver(operandResolver);
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/VariableResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/VariableResolverResource.cs
@@ -34,7 +34,21 @@ public partial class VariableResolverResource : StatescriptResolverResource
 			return;
 		}
 
-		runtimeNode.BindInput(index, new StringKey(VariableName));
+		Type? variableType = FindGraphVariableType(graph, VariableName);
+		var variableKey = new StringKey(VariableName);
+
+		if (variableType is not null && NeedsNumericInputAdaptation(runtimeNode, index, variableType))
+		{
+			DefineAndBindInputProperty(
+				graph,
+				runtimeNode,
+				$"__var_{nodeId}_{index}",
+				index,
+				new VariableResolver(variableKey, variableType));
+			return;
+		}
+
+		runtimeNode.BindInput(index, variableKey);
 	}
 
 	/// <inheritdoc/>

--- a/addons/forge/resources/statescript/resolvers/VariantResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/VariantResolverResource.cs
@@ -73,9 +73,13 @@ public partial class VariantResolverResource : StatescriptResolverResource
 		{
 			Variant128 value = StatescriptVariableTypeConverter.GodotVariantToForge(Value, ValueType);
 			Type clrType = StatescriptVariableTypeConverter.ToSystemType(ValueType);
-
-			graph.VariableDefinitions.PropertyDefinitions.Add(
-				new PropertyDefinition(propertyName, new VariantResolver(value, clrType)));
+			DefineAndBindInputProperty(
+				graph,
+				runtimeNode,
+				propertyName.ToString(),
+				index,
+				new VariantResolver(value, clrType));
+			return;
 		}
 
 		runtimeNode.BindInput(index, propertyName);

--- a/addons/forge/resources/statescript/resolvers/VectorFromValuesResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/VectorFromValuesResolverResource.cs
@@ -52,10 +52,18 @@ public partial class VectorFromValuesResolverResource : StatescriptResolverResou
 
 	public override IPropertyResolver BuildResolver(Graph graph)
 	{
-		IPropertyResolver xResolver = X?.BuildResolver(graph) ?? CreateDefaultComponentResolver();
-		IPropertyResolver yResolver = Y?.BuildResolver(graph) ?? CreateDefaultComponentResolver();
-		IPropertyResolver zResolver = Z?.BuildResolver(graph) ?? CreateDefaultComponentResolver();
-		IPropertyResolver wResolver = W?.BuildResolver(graph) ?? CreateDefaultComponentResolver();
+		IPropertyResolver xResolver = AdaptResolverForExpectedType(
+			X?.BuildResolver(graph) ?? CreateDefaultComponentResolver(),
+			typeof(float));
+		IPropertyResolver yResolver = AdaptResolverForExpectedType(
+			Y?.BuildResolver(graph) ?? CreateDefaultComponentResolver(),
+			typeof(float));
+		IPropertyResolver zResolver = AdaptResolverForExpectedType(
+			Z?.BuildResolver(graph) ?? CreateDefaultComponentResolver(),
+			typeof(float));
+		IPropertyResolver wResolver = AdaptResolverForExpectedType(
+			W?.BuildResolver(graph) ?? CreateDefaultComponentResolver(),
+			typeof(float));
 
 		return GetNormalizedValueType() switch
 		{

--- a/addons/forge/resources/statescript/resolvers/bases/BinaryNestedResolverResourceBase.cs
+++ b/addons/forge/resources/statescript/resolvers/bases/BinaryNestedResolverResourceBase.cs
@@ -33,9 +33,7 @@ public abstract partial class BinaryNestedResolverResourceBase : StatescriptReso
 	public override void BindInput(Graph graph, ForgeNode runtimeNode, string nodeId, byte index)
 	{
 		IPropertyResolver resolver = BuildResolver(graph);
-		var propertyName = new StringKey($"{PropertyNamePrefix}_{nodeId}_{index}");
-		graph.VariableDefinitions.DefineProperty(propertyName, resolver);
-		runtimeNode.BindInput(index, propertyName);
+		DefineAndBindInputProperty(graph, runtimeNode, $"{PropertyNamePrefix}_{nodeId}_{index}", index, resolver);
 	}
 
 	public override IPropertyResolver BuildResolver(Graph graph)

--- a/addons/forge/resources/statescript/resolvers/bases/RandomlessConstantResolverResourceBase.cs
+++ b/addons/forge/resources/statescript/resolvers/bases/RandomlessConstantResolverResourceBase.cs
@@ -19,9 +19,7 @@ public abstract partial class RandomlessConstantResolverResourceBase : Statescri
 #pragma warning restore SA1202 // Elements should be ordered by access
 	{
 		IPropertyResolver resolver = BuildResolver(graph);
-		var propertyName = new StringKey($"{PropertyNamePrefix}_{nodeId}_{index}");
-		graph.VariableDefinitions.DefineProperty(propertyName, resolver);
-		runtimeNode.BindInput(index, propertyName);
+		DefineAndBindInputProperty(graph, runtimeNode, $"{PropertyNamePrefix}_{nodeId}_{index}", index, resolver);
 	}
 
 	public override IPropertyResolver BuildResolver(Graph graph)

--- a/addons/forge/resources/statescript/resolvers/bases/TernaryNestedResolverResourceBase.cs
+++ b/addons/forge/resources/statescript/resolvers/bases/TernaryNestedResolverResourceBase.cs
@@ -40,9 +40,7 @@ public abstract partial class TernaryNestedResolverResourceBase : StatescriptRes
 	public override void BindInput(Graph graph, ForgeNode runtimeNode, string nodeId, byte index)
 	{
 		IPropertyResolver resolver = BuildResolver(graph);
-		var propertyName = new StringKey($"{PropertyNamePrefix}_{nodeId}_{index}");
-		graph.VariableDefinitions.DefineProperty(propertyName, resolver);
-		runtimeNode.BindInput(index, propertyName);
+		DefineAndBindInputProperty(graph, runtimeNode, $"{PropertyNamePrefix}_{nodeId}_{index}", index, resolver);
 	}
 
 	public override IPropertyResolver BuildResolver(Graph graph)

--- a/addons/forge/resources/statescript/resolvers/bases/TypedConstantResolverResourceBase.cs
+++ b/addons/forge/resources/statescript/resolvers/bases/TypedConstantResolverResourceBase.cs
@@ -17,22 +17,16 @@ public abstract partial class TypedConstantResolverResourceBase : StatescriptRes
 	protected abstract IPropertyResolver CreateResolver(Type valueType);
 
 	[Export]
-	public StatescriptVariableType ValueType { get; set; } = StatescriptVariableType.Float;
+	public StatescriptVariableType ValueType { get; set; } = StatescriptVariableType.Double;
 
 	public override void BindInput(Graph graph, ForgeNode runtimeNode, string nodeId, byte index)
 	{
 		IPropertyResolver resolver = BuildResolver(graph);
-		var propertyName = new StringKey($"{PropertyNamePrefix}_{nodeId}_{index}");
-		graph.VariableDefinitions.DefineProperty(propertyName, resolver);
-		runtimeNode.BindInput(index, propertyName);
+		DefineAndBindInputProperty(graph, runtimeNode, $"{PropertyNamePrefix}_{nodeId}_{index}", index, resolver);
 	}
 
 	public override IPropertyResolver BuildResolver(Graph graph)
 	{
-		Type valueType = StatescriptVariableTypeConverter.ToSystemType(ValueType == StatescriptVariableType.Double
-			? StatescriptVariableType.Double
-			: StatescriptVariableType.Float);
-
-		return CreateResolver(valueType);
+		return CreateResolver(StatescriptVariableTypeConverter.ToSystemType(StatescriptVariableType.Double));
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/bases/TypedConstantResolverResourceBase.cs
+++ b/addons/forge/resources/statescript/resolvers/bases/TypedConstantResolverResourceBase.cs
@@ -1,7 +1,6 @@
 // Copyright © Gamesmiths Guild.
 
 using System;
-using Gamesmiths.Forge.Core;
 using Gamesmiths.Forge.Statescript;
 using Gamesmiths.Forge.Statescript.Properties;
 using Godot;
@@ -27,6 +26,6 @@ public abstract partial class TypedConstantResolverResourceBase : StatescriptRes
 
 	public override IPropertyResolver BuildResolver(Graph graph)
 	{
-		return CreateResolver(StatescriptVariableTypeConverter.ToSystemType(StatescriptVariableType.Double));
+		return CreateResolver(StatescriptVariableTypeConverter.ToSystemType(ValueType));
 	}
 }

--- a/addons/forge/resources/statescript/resolvers/bases/UnaryNestedResolverResourceBase.cs
+++ b/addons/forge/resources/statescript/resolvers/bases/UnaryNestedResolverResourceBase.cs
@@ -24,9 +24,7 @@ public abstract partial class UnaryNestedResolverResourceBase : StatescriptResol
 	public override void BindInput(Graph graph, ForgeNode runtimeNode, string nodeId, byte index)
 	{
 		IPropertyResolver resolver = BuildResolver(graph);
-		var propertyName = new StringKey($"{PropertyNamePrefix}_{nodeId}_{index}");
-		graph.VariableDefinitions.DefineProperty(propertyName, resolver);
-		runtimeNode.BindInput(index, propertyName);
+		DefineAndBindInputProperty(graph, runtimeNode, $"{PropertyNamePrefix}_{nodeId}_{index}", index, resolver);
 	}
 
 	public override IPropertyResolver BuildResolver(Graph graph)

--- a/docs/statescript/resolvers.md
+++ b/docs/statescript/resolvers.md
@@ -6,6 +6,8 @@ For how resolvers fit into Statescript's data flow, see [Variables and Data](var
 
 This page keeps the Godot documentation concise by listing the resolvers available in Forge for Godot and linking to the corresponding core Forge documentation for resolver behavior details where available.
 
+In the Godot editor, resolver authoring is simplified to the same designer-facing scalar types used by variables: `Int` and `Float`. The visible `Float` option is backed by Forge's `double` path internally, and compatible numeric inputs are coerced explicitly when graphs are built.
+
 > **Note:** `ActivationDataResolver` is specific to Forge for Godot's Statescript workflow, so it does not have a matching page in the core Forge resolver reference.
 
 ## Built-in Resolvers
@@ -148,4 +150,4 @@ This page keeps the Godot documentation concise by listing the resolvers availab
 | [RandomInsideCircleResolver](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/resolvers/randominsidecircle-resolver.md) | `Vector2` | Returns a random point inside the unit circle. |
 | [RandomInsideSphereResolver](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/resolvers/randominsidesphere-resolver.md) | `Vector3` | Returns a random point inside the unit sphere. |
 | [RandomOnSphereResolver](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/resolvers/randomonsphere-resolver.md) | `Vector3` | Returns a random normalized 3D direction on the unit sphere. |
-| [RandomResolver](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/resolvers/random-resolver.md) | `int`/`float`/`double` | Generates a random value in a range using an `IRandom` provider. |
+| [RandomResolver](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/resolvers/random-resolver.md) | `int`/`float` | Generates a random value in a range using an `IRandom` provider. |

--- a/docs/statescript/resolvers.md
+++ b/docs/statescript/resolvers.md
@@ -6,7 +6,7 @@ For how resolvers fit into Statescript's data flow, see [Variables and Data](var
 
 This page keeps the Godot documentation concise by listing the resolvers available in Forge for Godot and linking to the corresponding core Forge documentation for resolver behavior details where available.
 
-In the Godot editor, resolver authoring is simplified to the same designer-facing scalar types used by variables: `Int` and `Float`. The visible `Float` option is backed by Forge's `double` path internally, and compatible numeric inputs are coerced explicitly when graphs are built.
+The type names in the tables below follow the underlying Forge/runtime terminology used by the linked resolver docs. In the Godot editor, numeric resolver authoring is simplified to the same designer-facing scalar types used by variables: `Int` for integral CLR types, and `Float` for floating-point CLR types such as `float`, `double`, and `decimal`. The visible `Float` option is backed by Forge's `double` path by default, and compatible numeric inputs are coerced explicitly when graphs are built.
 
 > **Note:** `ActivationDataResolver` is specific to Forge for Godot's Statescript workflow, so it does not have a matching page in the core Forge resolver reference.
 
@@ -150,4 +150,4 @@ In the Godot editor, resolver authoring is simplified to the same designer-facin
 | [RandomInsideCircleResolver](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/resolvers/randominsidecircle-resolver.md) | `Vector2` | Returns a random point inside the unit circle. |
 | [RandomInsideSphereResolver](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/resolvers/randominsidesphere-resolver.md) | `Vector3` | Returns a random point inside the unit sphere. |
 | [RandomOnSphereResolver](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/resolvers/randomonsphere-resolver.md) | `Vector3` | Returns a random normalized 3D direction on the unit sphere. |
-| [RandomResolver](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/resolvers/random-resolver.md) | `int`/`float` | Generates a random value in a range using an `IRandom` provider. |
+| [RandomResolver](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/resolvers/random-resolver.md) | `Int`/`Float` | Generates a random value in a range using an `IRandom` provider. |

--- a/docs/statescript/variables.md
+++ b/docs/statescript/variables.md
@@ -8,9 +8,11 @@ For C# API details and code examples, see the [core Variables documentation](htt
 
 Graph variables are **mutable values** scoped to a single graph execution instance. They are defined at graph construction time with a name, type, and initial value. When a graph starts, each variable is initialized from its definition. Multiple executions of the same graph each get their own independent copy.
 
-**Supported types:**
+**Supported authoring types in Godot:**
 
-All types supported by `Variant128`: `bool`, `byte`, `sbyte`, `char`, `decimal`, `double`, `float`, `int`, `uint`, `long`, `ulong`, `short`, `ushort`, `Vector2`, `Vector3`, `Vector4`, `Plane`, `Quaternion`.
+`Bool`, `Int`, `Float`, `Vector2`, `Vector3`, `Vector4`, `Plane`, and `Quaternion`.
+
+In the Godot editor, `Float` is the single designer-facing floating-point choice. It is backed by Forge's `double` path so it stays compatible with the broader numeric support in the core library, while still presenting a simpler authoring model.
 
 **Array variables** are also supported. These hold a fixed-length list of `Variant128` values.
 
@@ -46,7 +48,7 @@ Shared variables are **entity-level values** accessible by all Statescript graph
 
 ### Defining Shared Variables
 
-In Godot, shared variables are defined through a `ForgeSharedVariableSet` resource assigned to the `ForgeEntity` node's `SharedVariableDefinitions` property. Each shared variable has a name, type, and initial value.
+In Godot, shared variables are defined through a `ForgeSharedVariableSet` resource assigned to the `ForgeEntity` node's `SharedVariableDefinitions` property. Each shared variable has a name, type, and initial value, using the same simplified authoring types as graph variables.
 
 When the entity initializes, the shared variable set populates the entity's `SharedVariables` bag. All Statescript graphs running on that entity can then read and write these variables.
 
@@ -65,6 +67,8 @@ When the entity initializes, the shared variable set populates the entity's `Sha
 Property resolvers provide **read-only computed values** that nodes can bind to as input properties. Each resolver implements `IPropertyResolver` and returns a `Variant128` given a `GraphContext`.
 
 Resolvers are bound to node input properties at graph construction time. At runtime, when a node needs to read an input, the resolver computes the value from the current graph and entity state.
+
+When a Godot-authored variable or resolver output needs to feed a different compatible numeric type, Forge for Godot inserts an explicit numeric coercion step during graph build instead of relying on raw `Variant128` reads. That keeps the simplified `Int`/`Float` authoring model safe for existing core resolver signatures.
 
 For the full built-in resolver reference, see [Property Resolvers](resolvers.md). For how to create your own resolvers, see [Custom Resolvers](custom-resolvers.md).
 


### PR DESCRIPTION
## Changes

- Simplified supported variables and resolver types.

Now users can only select:
- Bool
- Int
- Float
- Vectors
- Quaternion
- Plane

Floats are backed by double for greater precision below the hood.