### PR TITLE
Fixed editor undo operations and resource cleanup.

### DIFF
--- a/addons/forge/ForgePluginLoader.cs
+++ b/addons/forge/ForgePluginLoader.cs
@@ -37,6 +37,7 @@ public partial class ForgePluginLoader : EditorPlugin
 		EnsureForgeDataExists();
 
 		_tagsEditorDock = new TagsEditorDock();
+		_tagsEditorDock.SetUndoRedo(GetUndoRedo());
 		AddDock(_tagsEditorDock);
 
 		_tagContainerInspectorPlugin = new TagContainerInspectorPlugin();

--- a/addons/forge/editor/EditorUndoRedoUtils.cs
+++ b/addons/forge/editor/EditorUndoRedoUtils.cs
@@ -1,0 +1,48 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using System;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Editor;
+
+/// <summary>
+/// Shared helpers for recording editor undo/redo actions, centralizing the repeated
+/// <c>CreateAction</c> / <c>AddDoMethod</c> / <c>AddUndoMethod</c> / <c>CommitAction</c> boilerplate.
+/// </summary>
+internal static class EditorUndoRedoUtils
+{
+	/// <summary>
+	/// Records an undo/redo action. When <paramref name="undoRedo"/> is available, opens an action, lets
+	/// <paramref name="configure"/> register the do/undo methods, and commits it. When it is <see langword="null"/>,
+	/// the optional <paramref name="fallback"/> is invoked so the change still happens without undo support.
+	/// </summary>
+	/// <param name="undoRedo">The undo/redo manager, or <see langword="null"/> when unavailable.</param>
+	/// <param name="actionName">The undo/redo action label.</param>
+	/// <param name="context">The custom context (usually the edited resource) used to scope the action.</param>
+	/// <param name="configure">Callback that registers the do/undo methods on the action.</param>
+	/// <param name="execute">
+	/// Whether committing should immediately run the registered do-methods. Pass <see langword="false"/> when the
+	/// change has already been applied before recording.
+	/// </param>
+	/// <param name="fallback">Invoked to apply the change when no undo manager is available.</param>
+	public static void Record(
+		EditorUndoRedoManager? undoRedo,
+		string actionName,
+		GodotObject? context,
+		Action<EditorUndoRedoManager> configure,
+		bool execute = false,
+		Action? fallback = null)
+	{
+		if (undoRedo is null)
+		{
+			fallback?.Invoke();
+			return;
+		}
+
+		undoRedo.CreateAction(actionName, customContext: context);
+		configure(undoRedo);
+		undoRedo.CommitAction(execute);
+	}
+}
+#endif

--- a/addons/forge/editor/EditorUndoRedoUtils.cs.uid
+++ b/addons/forge/editor/EditorUndoRedoUtils.cs.uid
@@ -1,0 +1,1 @@
+uid://hwhdkhe2uqp1

--- a/addons/forge/editor/statescript/CustomNodeEditor.cs
+++ b/addons/forge/editor/statescript/CustomNodeEditor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Gamesmiths.Forge.Godot.Resources.Statescript;
 using Godot;
+using GodotCollections = Godot.Collections;
 
 namespace Gamesmiths.Forge.Godot.Editor.Statescript;
 
@@ -133,7 +134,7 @@ internal abstract partial class CustomNodeEditor : RefCounted, ISerializationLis
 		foreach (Node child in container.GetChildren())
 		{
 			container.RemoveChild(child);
-			child.Free();
+			child.QueueFree();
 		}
 	}
 
@@ -159,20 +160,23 @@ internal abstract partial class CustomNodeEditor : RefCounted, ISerializationLis
 	/// <param name="propInfo">Metadata about the input property.</param>
 	/// <param name="index">Index of the input property.</param>
 	/// <param name="container">Container to add the input property row to.</param>
-	/// <param name="onShapeChanged">Callback invoked when the shape of the input property changes.</param>
+	/// <param name="shapeCustomDataKey">
+	/// When provided, enables the row's single/array shape dropdown and wires it to undo-tracked
+	/// type/shape changes that persist the new shape under this CustomData key. When null the dropdown is disabled.
+	/// </param>
 	/// <param name="preferredDefaultResolverTypeId">The preferred default resolver type ID.</param>
 	protected void AddInputPropertyRow(
 		StatescriptNodeDiscovery.InputPropertyInfo propInfo,
 		int index,
 		Control container,
-		Action<bool>? onShapeChanged = null,
+		string? shapeCustomDataKey = null,
 		string? preferredDefaultResolverTypeId = null)
 	{
 		_graphNode!.AddInputPropertyRowInternal(
 			propInfo,
 			index,
 			container,
-			onShapeChanged,
+			shapeCustomDataKey,
 			preferredDefaultResolverTypeId);
 	}
 
@@ -337,6 +341,26 @@ internal abstract partial class CustomNodeEditor : RefCounted, ISerializationLis
 			oldResolver,
 			newResolver,
 			actionName);
+	}
+
+	/// <summary>
+	/// Changes the type/shape configuration of an input-property slot with full undo/redo support.
+	/// </summary>
+	/// <remarks>
+	/// Custom dropdowns (such as a value-type picker) call this directly; the standard single/array shape dropdown
+	/// created by <see cref="AddInputPropertyRow"/> is wired to the same engine automatically. The given CustomData
+	/// entries are persisted, the slot's resolver binding is reset, and the node is rebuilt — all as one undoable
+	/// action. No per-node bookkeeping is required.
+	/// </remarks>
+	/// <param name="propertyIndex">The input slot whose configuration changes.</param>
+	/// <param name="customData">The CustomData entries to store (e.g. value type and/or array shape).</param>
+	/// <param name="actionName">The undo/redo action label.</param>
+	protected void ChangeInputPropertyConfig(
+		int propertyIndex,
+		GodotCollections.Dictionary customData,
+		string actionName)
+	{
+		_graphNode!.ChangeInputPropertyConfigInternal(propertyIndex, customData, actionName);
 	}
 }
 #endif

--- a/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
+++ b/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
@@ -529,6 +529,12 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 			SizeFlagsHorizontal = SizeFlags.ExpandFill,
 		};
 
+		if (def.VariableType == StatescriptVariableType.Entity)
+		{
+			vBox.AddChild(new Label { Text = "Runtime-assigned entity references." });
+			return vBox;
+		}
+
 		var headerRow = new HBoxContainer();
 		vBox.AddChild(headerRow);
 
@@ -575,12 +581,6 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 		};
 
 		headerRow.AddChild(toggleButton);
-
-		if (def.VariableType == StatescriptVariableType.Entity)
-		{
-			vBox.AddChild(new Label { Text = "Runtime-assigned entity references." });
-			return vBox;
-		}
 
 		var addElementButton = new Button
 		{

--- a/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
+++ b/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
@@ -563,21 +563,15 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 				_expandedArrays.Remove(def.VariableName);
 			}
 
-			if (_undoRedo is not null)
-			{
-				_undoRedo.CreateAction("Toggle Array Expand");
-				_undoRedo.AddDoMethod(
-					this,
-					MethodName.DoSetArrayExpanded,
-					def.VariableName,
-					x);
-				_undoRedo.AddUndoMethod(
-					this,
-					MethodName.DoSetArrayExpanded,
-					def.VariableName,
-					wasExpanded);
-				_undoRedo.CommitAction(false);
-			}
+			EditorUndoRedoUtils.Record(
+				_undoRedo,
+				"Toggle Array Expand",
+				null,
+				undo =>
+				{
+					undo.AddDoMethod(this, MethodName.DoSetArrayExpanded, def.VariableName, x);
+					undo.AddUndoMethod(this, MethodName.DoSetArrayExpanded, def.VariableName, wasExpanded);
+				});
 		};
 
 		headerRow.AddChild(toggleButton);
@@ -703,13 +697,15 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 		def.InitialValue = newValue;
 		NotifyChanged();
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction($"Change Shared Variable '{def.VariableName}'");
-			_undoRedo.AddDoMethod(this, MethodName.ApplyVariableValue, def, newValue);
-			_undoRedo.AddUndoMethod(this, MethodName.ApplyVariableValue, def, oldValue);
-			_undoRedo.CommitAction(false);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			$"Change Shared Variable '{def.VariableName}'",
+			null,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.ApplyVariableValue, def, newValue);
+				undo.AddUndoMethod(this, MethodName.ApplyVariableValue, def, oldValue);
+			});
 	}
 
 	private void SetArrayElementValue(ForgeSharedVariableDefinition def, int index, Variant newValue)
@@ -719,30 +715,32 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 		def.InitialArrayValues[index] = newValue;
 		NotifyChanged();
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction($"Change Shared Variable '{def.VariableName}' Element [{index}]");
-			_undoRedo.AddDoMethod(this, MethodName.ApplyArrayElementValue, def, index, newValue);
-			_undoRedo.AddUndoMethod(this, MethodName.ApplyArrayElementValue, def, index, oldValue);
-			_undoRedo.CommitAction(false);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			$"Change Shared Variable '{def.VariableName}' Element [{index}]",
+			null,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.ApplyArrayElementValue, def, index, newValue);
+				undo.AddUndoMethod(this, MethodName.ApplyArrayElementValue, def, index, oldValue);
+			});
 	}
 
 	private void AddArrayElement(ForgeSharedVariableDefinition def, Variant value)
 	{
 		bool wasExpanded = _expandedArrays.Contains(def.VariableName);
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction($"Add Element to '{def.VariableName}'");
-			_undoRedo.AddDoMethod(this, MethodName.DoAddArrayElement, def, value);
-			_undoRedo.AddUndoMethod(this, MethodName.UndoAddArrayElement, def, wasExpanded);
-			_undoRedo.CommitAction();
-		}
-		else
-		{
-			DoAddArrayElement(def, value);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			$"Add Element to '{def.VariableName}'",
+			null,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.DoAddArrayElement, def, value);
+				undo.AddUndoMethod(this, MethodName.UndoAddArrayElement, def, wasExpanded);
+			},
+			execute: true,
+			fallback: () => DoAddArrayElement(def, value));
 	}
 
 	private void RemoveArrayElement(ForgeSharedVariableDefinition def, int index)
@@ -754,17 +752,17 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 		Variant oldValue = def.InitialArrayValues[index];
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction($"Remove Element [{index}] from '{def.VariableName}'");
-			_undoRedo.AddDoMethod(this, MethodName.DoRemoveArrayElement, def, index);
-			_undoRedo.AddUndoMethod(this, MethodName.UndoRemoveArrayElement, def, index, oldValue);
-			_undoRedo.CommitAction();
-		}
-		else
-		{
-			DoRemoveArrayElement(def, index);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			$"Remove Element [{index}] from '{def.VariableName}'",
+			null,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.DoRemoveArrayElement, def, index);
+				undo.AddUndoMethod(this, MethodName.UndoRemoveArrayElement, def, index, oldValue);
+			},
+			execute: true,
+			fallback: () => DoRemoveArrayElement(def, index));
 	}
 
 	private void OnAddPressed()
@@ -841,17 +839,17 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 		Array<ForgeSharedVariableDefinition> definitions = GetDefinitions();
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction("Add Shared Variable");
-			_undoRedo.AddDoMethod(this, MethodName.DoAddVariable, definitions, newDef);
-			_undoRedo.AddUndoMethod(this, MethodName.UndoAddVariable, definitions, newDef);
-			_undoRedo.CommitAction();
-		}
-		else
-		{
-			DoAddVariable(definitions, newDef);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			"Add Shared Variable",
+			null,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.DoAddVariable, definitions, newDef);
+				undo.AddUndoMethod(this, MethodName.UndoAddVariable, definitions, newDef);
+			},
+			execute: true,
+			fallback: () => DoAddVariable(definitions, newDef));
 
 		CleanupCreationDialog();
 	}
@@ -881,17 +879,17 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 		ForgeSharedVariableDefinition variable = definitions[index];
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction("Remove Shared Variable");
-			_undoRedo.AddDoMethod(this, MethodName.DoRemoveVariable, definitions, variable, index);
-			_undoRedo.AddUndoMethod(this, MethodName.UndoRemoveVariable, definitions, variable, index);
-			_undoRedo.CommitAction();
-		}
-		else
-		{
-			DoRemoveVariable(definitions, index);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			"Remove Shared Variable",
+			null,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.DoRemoveVariable, definitions, variable, index);
+				undo.AddUndoMethod(this, MethodName.UndoRemoveVariable, definitions, variable, index);
+			},
+			execute: true,
+			fallback: () => DoRemoveVariable(definitions, index));
 	}
 
 	private void ApplyVariableValue(ForgeSharedVariableDefinition def, Variant value)

--- a/addons/forge/editor/statescript/StatescriptGraphEditorDock.GraphOperations.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphEditorDock.GraphOperations.cs
@@ -64,29 +64,17 @@ public partial class StatescriptGraphEditorDock
 			return;
 		}
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction("Connect Statescript Nodes", customContext: graph);
-			_undoRedo.AddDoMethod(
-				this,
-				MethodName.DoConnect,
-				fromNodeId,
-				runtimeFromPort,
-				toNodeId,
-				runtimeToPort);
-			_undoRedo.AddUndoMethod(
-				this,
-				MethodName.UndoConnect,
-				fromNodeId,
-				runtimeFromPort,
-				toNodeId,
-				runtimeToPort);
-			_undoRedo.CommitAction();
-		}
-		else
-		{
-			DoConnect(fromNodeId, runtimeFromPort, toNodeId, runtimeToPort);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			"Connect Statescript Nodes",
+			graph,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.DoConnect, fromNodeId, runtimeFromPort, toNodeId, runtimeToPort);
+				undo.AddUndoMethod(this, MethodName.UndoConnect, fromNodeId, runtimeFromPort, toNodeId, runtimeToPort);
+			},
+			execute: true,
+			fallback: () => DoConnect(fromNodeId, runtimeFromPort, toNodeId, runtimeToPort));
 	}
 
 	private void DoConnect(string fromNode, int fromPort, string toNode, int toPort)
@@ -114,30 +102,21 @@ public partial class StatescriptGraphEditorDock
 		int runtimeFromPort = ToRuntimeOutputPort(fromNodeId, (int)fromPort);
 		int runtimeToPort = (int)toPort;
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction("Disconnect Statescript Nodes", customContext: graph);
-			_undoRedo.AddDoMethod(
-				this,
-				MethodName.UndoConnect,
-				fromNodeId,
-				runtimeFromPort,
-				toNodeId,
-				runtimeToPort);
-			_undoRedo.AddUndoMethod(
-				this,
-				MethodName.DoConnect,
-				fromNodeId,
-				runtimeFromPort,
-				toNodeId,
-				runtimeToPort);
-			_undoRedo.CommitAction();
-		}
-		else
-		{
-			_graphEdit.DisconnectNode(fromNode, (int)fromPort, toNode, (int)toPort);
-			SyncConnectionsToCurrentGraph();
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			"Disconnect Statescript Nodes",
+			graph,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.UndoConnect, fromNodeId, runtimeFromPort, toNodeId, runtimeToPort);
+				undo.AddUndoMethod(this, MethodName.DoConnect, fromNodeId, runtimeFromPort, toNodeId, runtimeToPort);
+			},
+			execute: true,
+			fallback: () =>
+			{
+				_graphEdit.DisconnectNode(fromNode, (int)fromPort, toNode, (int)toPort);
+				SyncConnectionsToCurrentGraph();
+			});
 	}
 
 	private void OnDeleteNodesRequest(GodotCollections.Array<StringName> deletedNodes)
@@ -188,30 +167,28 @@ public partial class StatescriptGraphEditorDock
 				}
 			}
 
-			if (_undoRedo is not null)
-			{
-				_undoRedo.CreateAction("Delete Statescript Node", customContext: graph);
-				_undoRedo.AddDoMethod(
-					this,
-					MethodName.DoDeleteNode,
-					graph,
-					graphNode.NodeResource,
-					new GodotCollections.Array<StatescriptConnection>(affectedConnections));
-				_undoRedo.AddUndoMethod(
-					this,
-					MethodName.UndoDeleteNode,
-					graph,
-					graphNode.NodeResource,
-					new GodotCollections.Array<StatescriptConnection>(affectedConnections));
-				_undoRedo.CommitAction();
-			}
-			else
-			{
-				DoDeleteNode(
-					graph,
-					graphNode.NodeResource,
-					[.. affectedConnections]);
-			}
+			StatescriptNode nodeResource = graphNode.NodeResource;
+			EditorUndoRedoUtils.Record(
+				_undoRedo,
+				"Delete Statescript Node",
+				graph,
+				undo =>
+				{
+					undo.AddDoMethod(
+						this,
+						MethodName.DoDeleteNode,
+						graph,
+						nodeResource,
+						new GodotCollections.Array<StatescriptConnection>(affectedConnections));
+					undo.AddUndoMethod(
+						this,
+						MethodName.UndoDeleteNode,
+						graph,
+						nodeResource,
+						new GodotCollections.Array<StatescriptConnection>(affectedConnections));
+				},
+				execute: true,
+				fallback: () => DoDeleteNode(graph, nodeResource, [.. affectedConnections]));
 		}
 	}
 
@@ -307,13 +284,15 @@ public partial class StatescriptGraphEditorDock
 			return;
 		}
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction("Move Statescript Node(s)", customContext: graph);
-			_undoRedo.AddDoMethod(this, MethodName.DoMoveNodes, graph, movedNodes);
-			_undoRedo.AddUndoMethod(this, MethodName.DoMoveNodes, graph, oldPositions);
-			_undoRedo.CommitAction(false);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			"Move Statescript Node(s)",
+			graph,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.DoMoveNodes, graph, movedNodes);
+				undo.AddUndoMethod(this, MethodName.DoMoveNodes, graph, oldPositions);
+			});
 
 		SyncNodePositionsToResource(graph, movedNodes);
 	}
@@ -365,17 +344,17 @@ public partial class StatescriptGraphEditorDock
 			PositionOffset = position,
 		};
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction("Add Statescript Node", customContext: graph);
-			_undoRedo.AddDoMethod(this, MethodName.DoAddNode, graph, nodeResource);
-			_undoRedo.AddUndoMethod(this, MethodName.UndoAddNode, graph, nodeResource);
-			_undoRedo.CommitAction();
-		}
-		else
-		{
-			DoAddNode(graph, nodeResource);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			"Add Statescript Node",
+			graph,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.DoAddNode, graph, nodeResource);
+				undo.AddUndoMethod(this, MethodName.UndoAddNode, graph, nodeResource);
+			},
+			execute: true,
+			fallback: () => DoAddNode(graph, nodeResource));
 
 		return nodeId;
 	}
@@ -436,6 +415,7 @@ public partial class StatescriptGraphEditorDock
 		}
 
 		var duplicatedIds = new Dictionary<string, string>();
+		var duplicatedNodes = new GodotCollections.Array<StatescriptNode>();
 		const float offset = 40f;
 
 		foreach (StatescriptGraphNode sgn in selectedNodes)
@@ -472,29 +452,100 @@ public partial class StatescriptGraphEditorDock
 				duplicated.PropertyBindings.Add(newBinding);
 			}
 
-			graph.Nodes.Add(duplicated);
-			graph.EmitChanged();
-
-			GraphTab? tab = FindTab(graph);
-			StatescriptGraphNode graphNode = AddGraphNodeVisual(duplicated, graph);
-			tab?.CachedGraphNodes.Add(graphNode);
-			graphNode.Selected = true;
+			duplicatedNodes.Add(duplicated);
 		}
 
+		var duplicatedConnections = new GodotCollections.Array<StatescriptConnection>();
 		foreach (StatescriptConnection connection in graph.Connections)
 		{
 			if (duplicatedIds.TryGetValue(connection.FromNode, out string? newFrom)
 				&& duplicatedIds.TryGetValue(connection.ToNode, out string? newTo))
 			{
-				_graphEdit.ConnectNode(
-					newFrom,
-					ToVisualOutputPort(newFrom, connection.OutputPort),
-					newTo,
-					connection.InputPort);
+				duplicatedConnections.Add(new StatescriptConnection
+				{
+					FromNode = newFrom,
+					OutputPort = connection.OutputPort,
+					ToNode = newTo,
+					InputPort = connection.InputPort,
+				});
 			}
 		}
 
-		SyncConnectionsToCurrentGraph();
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			"Duplicate Statescript Node(s)",
+			graph,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.DoDuplicateNodes, graph, duplicatedNodes, duplicatedConnections);
+				undo.AddUndoMethod(this, MethodName.UndoDuplicateNodes, graph, duplicatedNodes, duplicatedConnections);
+			},
+			execute: true,
+			fallback: () => DoDuplicateNodes(graph, duplicatedNodes, duplicatedConnections));
+	}
+
+	private void DoDuplicateNodes(
+		StatescriptGraph graph,
+		GodotCollections.Array<StatescriptNode> nodes,
+		GodotCollections.Array<StatescriptConnection> connections)
+	{
+		graph.Nodes.AddRange(nodes);
+
+		graph.Connections.AddRange(connections);
+		graph.EmitChanged();
+
+		if (CurrentGraph == graph)
+		{
+			InvalidateCachedGraphVisuals(graph);
+			LoadGraphIntoEditor(graph);
+			SelectGraphNodes(graph, nodes);
+		}
+	}
+
+	private void UndoDuplicateNodes(
+		StatescriptGraph graph,
+		GodotCollections.Array<StatescriptNode> nodes,
+		GodotCollections.Array<StatescriptConnection> connections)
+	{
+		foreach (StatescriptConnection connection in connections)
+		{
+			graph.Connections.Remove(connection);
+		}
+
+		foreach (StatescriptNode node in nodes)
+		{
+			graph.Nodes.Remove(node);
+		}
+
+		graph.EmitChanged();
+
+		if (CurrentGraph == graph)
+		{
+			InvalidateCachedGraphVisuals(graph);
+			LoadGraphIntoEditor(graph);
+		}
+	}
+
+	private void SelectGraphNodes(StatescriptGraph graph, GodotCollections.Array<StatescriptNode> nodes)
+	{
+		if (_graphEdit is null || CurrentGraph != graph)
+		{
+			return;
+		}
+
+		var ids = new HashSet<string>();
+		foreach (StatescriptNode node in nodes)
+		{
+			ids.Add(node.NodeId);
+		}
+
+		foreach (Node child in _graphEdit.GetChildren())
+		{
+			if (child is StatescriptGraphNode sgn && sgn.NodeResource is not null)
+			{
+				sgn.Selected = ids.Contains(sgn.NodeResource.NodeId);
+			}
+		}
 	}
 
 	private void ShowLoopWarningDialog()

--- a/addons/forge/editor/statescript/StatescriptGraphEditorDock.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphEditorDock.cs
@@ -112,9 +112,10 @@ public partial class StatescriptGraphEditorDock : EditorDock, ISerializationList
 		_fileSystem = EditorInterface.Singleton.GetResourceFilesystem();
 		_filesystemChangedCallable = new Callable(this, nameof(OnFilesystemChanged));
 
-		if (!_fileSystem.IsConnected(EditorFileSystem.SignalName.ResourcesReimported, _filesystemChangedCallable))
+		if (_fileSystem?.IsConnected(EditorFileSystem.SignalName.ResourcesReimported, _filesystemChangedCallable)
+			!= true)
 		{
-			_fileSystem.Connect(EditorFileSystem.SignalName.ResourcesReimported, _filesystemChangedCallable);
+			_fileSystem?.Connect(EditorFileSystem.SignalName.ResourcesReimported, _filesystemChangedCallable);
 		}
 
 		ConnectUISignals();

--- a/addons/forge/editor/statescript/StatescriptGraphNode.PropertyEditors.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.PropertyEditors.cs
@@ -7,6 +7,7 @@ using Gamesmiths.Forge.Godot.Resources.Statescript;
 using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
 using Gamesmiths.Forge.Statescript;
 using Godot;
+using GodotCollections = Godot.Collections;
 
 namespace Gamesmiths.Forge.Godot.Editor.Statescript;
 
@@ -18,7 +19,7 @@ public partial class StatescriptGraphNode
 		StatescriptNodeDiscovery.InputPropertyInfo propInfo,
 		int index,
 		Control sectionContainer,
-		Action<bool>? onShapeChanged = null,
+		string? shapeCustomDataKey = null,
 		string? preferredDefaultResolverTypeId = null)
 	{
 		if (NodeResource is null)
@@ -47,10 +48,17 @@ public partial class StatescriptGraphNode
 		headerRow.AddThemeConstantOverride("separation", 5);
 		container.AddChild(headerRow);
 
+		Action<bool>? onShapeChanged = shapeCustomDataKey is null
+			? null
+			: isArray => ChangeInputPropertyConfigInternal(
+				index,
+				new GodotCollections.Dictionary { { shapeCustomDataKey, isArray } },
+				"Change Input Shape");
+
 		OptionButton valueShapeDropdown =
 			StatescriptEditorControls.CreateValueShapeDropdown(propInfo.IsArray, onShapeChanged);
 
-		valueShapeDropdown.Disabled = onShapeChanged is null;
+		valueShapeDropdown.Disabled = shapeCustomDataKey is null;
 
 		List<Func<NodeEditorProperty>> resolverFactories =
 			StatescriptResolverRegistry.GetCompatibleFactories(propInfo.ExpectedType);

--- a/addons/forge/editor/statescript/StatescriptGraphNode.PropertyEditors.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.PropertyEditors.cs
@@ -212,26 +212,25 @@ public partial class StatescriptGraphNode
 		StatescriptNodeProperty? updated = FindBinding(StatescriptPropertyDirection.Input, index);
 		var newResolver = updated?.Resolver?.Duplicate() as StatescriptResolverResource;
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction("Change Resolver Type", customContext: _graph);
-
-			_undoRedo.AddDoMethod(
-				this,
-				MethodName.ApplyResolverBinding,
-				(int)StatescriptPropertyDirection.Input,
-				index,
-				Variant.From(newResolver));
-
-			_undoRedo.AddUndoMethod(
-				this,
-				MethodName.ApplyResolverBinding,
-				(int)StatescriptPropertyDirection.Input,
-				index,
-				Variant.From(oldResolver));
-
-			_undoRedo.CommitAction(false);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			"Change Resolver Type",
+			_graph,
+			undo =>
+			{
+				undo.AddDoMethod(
+					this,
+					MethodName.ApplyResolverBinding,
+					(int)StatescriptPropertyDirection.Input,
+					index,
+					Variant.From(newResolver));
+				undo.AddUndoMethod(
+					this,
+					MethodName.ApplyResolverBinding,
+					(int)StatescriptPropertyDirection.Input,
+					index,
+					Variant.From(oldResolver));
+			});
 
 		PropertyBindingChanged?.Invoke();
 		ResetSize();
@@ -329,26 +328,25 @@ public partial class StatescriptGraphNode
 		EnsureBinding(StatescriptPropertyDirection.Output, index).Resolver = newResolver;
 		NotifyGraphResourceChanged();
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction("Change Output Variable", customContext: _graph);
-
-			_undoRedo.AddDoMethod(
-				this,
-				MethodName.ApplyResolverBinding,
-				(int)StatescriptPropertyDirection.Output,
-				index,
-				(StatescriptResolverResource)newResolver.Duplicate());
-
-			_undoRedo.AddUndoMethod(
-				this,
-				MethodName.ApplyResolverBinding,
-				(int)StatescriptPropertyDirection.Output,
-				index,
-				Variant.From(oldResolver));
-
-			_undoRedo.CommitAction(false);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			"Change Output Variable",
+			_graph,
+			undo =>
+			{
+				undo.AddDoMethod(
+					this,
+					MethodName.ApplyResolverBinding,
+					(int)StatescriptPropertyDirection.Output,
+					index,
+					(StatescriptResolverResource)newResolver.Duplicate());
+				undo.AddUndoMethod(
+					this,
+					MethodName.ApplyResolverBinding,
+					(int)StatescriptPropertyDirection.Output,
+					index,
+					Variant.From(oldResolver));
+			});
 
 		PropertyBindingChanged?.Invoke();
 	}
@@ -404,26 +402,25 @@ public partial class StatescriptGraphNode
 		StatescriptNodeProperty? updated = FindBinding(direction, propertyIndex);
 		var newResolver = updated?.Resolver?.Duplicate() as StatescriptResolverResource;
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction("Change Node Property", customContext: _graph);
-
-			_undoRedo.AddDoMethod(
-				this,
-				MethodName.ApplyResolverBinding,
-				(int)direction,
-				propertyIndex,
-				Variant.From(newResolver));
-
-			_undoRedo.AddUndoMethod(
-				this,
-				MethodName.ApplyResolverBinding,
-				(int)direction,
-				propertyIndex,
-				Variant.From(oldResolver));
-
-			_undoRedo.CommitAction(false);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			"Change Node Property",
+			_graph,
+			undo =>
+			{
+				undo.AddDoMethod(
+					this,
+					MethodName.ApplyResolverBinding,
+					(int)direction,
+					propertyIndex,
+					Variant.From(newResolver));
+				undo.AddUndoMethod(
+					this,
+					MethodName.ApplyResolverBinding,
+					(int)direction,
+					propertyIndex,
+					Variant.From(oldResolver));
+			});
 
 		if (direction == StatescriptPropertyDirection.Input)
 		{

--- a/addons/forge/editor/statescript/StatescriptGraphNode.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.cs
@@ -736,10 +736,16 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		}
 
 		var direction = (StatescriptPropertyDirection)directionInt;
-		StatescriptNodeProperty binding = EnsureBinding(direction, propertyIndex);
-		binding.Resolver = resolverVariant.VariantType == Variant.Type.Nil
-			? null
-			: resolverVariant.AsGodotObject() as StatescriptResolverResource;
+
+		if (resolverVariant.AsGodotObject() is not StatescriptResolverResource resolver)
+		{
+			RemoveBinding(direction, propertyIndex);
+		}
+		else
+		{
+			EnsureBinding(direction, propertyIndex).Resolver = resolver;
+		}
+
 		EnsurePropertyVisible(direction, propertyIndex);
 		NotifyGraphResourceChanged();
 		RebuildNode();
@@ -842,7 +848,14 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 
 		foreach (KeyValuePair<Variant, Variant> entry in customData)
 		{
-			NodeResource.CustomData[entry.Key.AsString()] = entry.Value;
+			string key = entry.Key.AsString();
+			if (entry.Value.VariantType == Variant.Type.Nil)
+			{
+				NodeResource.CustomData.Remove(key);
+				continue;
+			}
+
+			NodeResource.CustomData[key] = entry.Value;
 		}
 
 		if (resolverVariant.VariantType == Variant.Type.Nil)

--- a/addons/forge/editor/statescript/StatescriptGraphNode.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.cs
@@ -46,6 +46,7 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 	private EditorUndoRedoManager? _undoRedo;
 	private CustomNodeEditor? _activeCustomEditor;
 	private bool _resizeConnected;
+	private bool _refittingSize;
 	private float _widthBeforeResize;
 	private string? _highlightedVariableName;
 	private string? _highlightedSharedVariableSetPath;
@@ -137,6 +138,11 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 			_widthBeforeResize = CustomMinimumSize.X;
 			ResizeRequest += OnResizeRequest;
 			ResizeEnd += OnResizeEnd;
+
+			// Re-fit whenever the combined minimum changes (section or nested-resolver collapse/expand, rebuilds,
+			// content edits). This signal fires after the minimum is recomputed, so the node reliably shrinks back to
+			// its floor instead of staying stretched at a stale, still-expanded width.
+			MinimumSizeChanged += OnNodeMinimumSizeChanged;
 			_resizeConnected = true;
 		}
 
@@ -259,27 +265,25 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		StatescriptResolverResource? newResolver,
 		string actionName)
 	{
-		if (_undoRedo is null)
-		{
-			return;
-		}
-
-		_undoRedo.CreateAction(actionName, customContext: _graph);
-		_undoRedo.AddDoMethod(
-			this,
-			MethodName.ApplyResolverBinding,
-			(int)direction,
-			propertyIndex,
-			Variant.From(newResolver));
-
-		_undoRedo.AddUndoMethod(
-			this,
-			MethodName.ApplyResolverBinding,
-			(int)direction,
-			propertyIndex,
-			Variant.From(oldResolver));
-
-		_undoRedo.CommitAction(false);
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			actionName,
+			_graph,
+			undo =>
+			{
+				undo.AddDoMethod(
+					this,
+					MethodName.ApplyResolverBinding,
+					(int)direction,
+					propertyIndex,
+					Variant.From(newResolver));
+				undo.AddUndoMethod(
+					this,
+					MethodName.ApplyResolverBinding,
+					(int)direction,
+					propertyIndex,
+					Variant.From(oldResolver));
+			});
 	}
 
 	internal void ShowResolverEditorUIInternal(
@@ -559,7 +563,26 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		UpdateInputPropertyFoldableTitles();
 		RefreshHighlightState();
 
-		ResetSize();
+		// Width/height re-fitting is handled by OnNodeMinimumSizeChanged, which fires once the foldable has recomputed
+		// its minimum size. Resetting here would measure against the still-expanded width.
+	}
+
+	private void OnNodeMinimumSizeChanged()
+	{
+		if (_refittingSize)
+		{
+			return;
+		}
+
+		_refittingSize = true;
+
+		// Pin the node to its combined minimum: max(CustomMinimumSize.X, content width) for width and the natural
+		// height. CustomMinimumSize.X is the floor (the user's custom width, or the default base width). Godot only
+		// enforces the lower bound on Size, so collapsing content requires applying the shrink explicitly here, where
+		// the freshly recomputed minimum is available.
+		Size = GetCombinedMinimumSize();
+
+		_refittingSize = false;
 	}
 
 	private void UpdateInputPropertyFoldableTitle(PropertySlotKey key)
@@ -624,21 +647,15 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 
 		SetFoldState(key, folded);
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction("Toggle Fold", customContext: _graph);
-			_undoRedo.AddDoMethod(
-				this,
-				MethodName.ApplyFoldState,
-				key,
-				folded);
-			_undoRedo.AddUndoMethod(
-				this,
-				MethodName.ApplyFoldState,
-				key,
-				oldFolded);
-			_undoRedo.CommitAction(false);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			"Toggle Fold",
+			_graph,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.ApplyFoldState, key, folded);
+				undo.AddUndoMethod(this, MethodName.ApplyFoldState, key, oldFolded);
+			});
 	}
 
 	private void ApplyFoldState(string key, bool folded)
@@ -658,21 +675,19 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 	{
 		float newWidth = CustomMinimumSize.X;
 
-		if (_undoRedo is not null && NodeResource is not null
-			&& !Mathf.IsEqualApprox(_widthBeforeResize, newWidth))
+		if (NodeResource is not null && !Mathf.IsEqualApprox(_widthBeforeResize, newWidth))
 		{
 			float oldWidth = _widthBeforeResize;
 
-			_undoRedo.CreateAction("Resize Node", customContext: _graph);
-			_undoRedo.AddDoMethod(
-				this,
-				MethodName.ApplyCustomWidth,
-				newWidth);
-			_undoRedo.AddUndoMethod(
-				this,
-				MethodName.ApplyCustomWidth,
-				oldWidth);
-			_undoRedo.CommitAction(false);
+			EditorUndoRedoUtils.Record(
+				_undoRedo,
+				"Resize Node",
+				_graph,
+				undo =>
+				{
+					undo.AddDoMethod(this, MethodName.ApplyCustomWidth, newWidth);
+					undo.AddUndoMethod(this, MethodName.ApplyCustomWidth, oldWidth);
+				});
 		}
 
 		_widthBeforeResize = newWidth;
@@ -725,8 +740,34 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		binding.Resolver = resolverVariant.VariantType == Variant.Type.Nil
 			? null
 			: resolverVariant.AsGodotObject() as StatescriptResolverResource;
+		EnsurePropertyVisible(direction, propertyIndex);
 		NotifyGraphResourceChanged();
 		RebuildNode();
+	}
+
+	/// <summary>
+	/// Expands the section (and the individual input-property foldable) that contains the given slot so an undo/redo or
+	/// programmatic change is never hidden inside a collapsed section. This only adjusts persisted fold state; it does
+	/// not record its own undo step, so user-driven collapse/expand remains the only fold action on the undo stack.
+	/// </summary>
+	/// <param name="direction">The direction of the property (input or output).</param>
+	/// <param name="propertyIndex">The index of the property.</param>
+	private void EnsurePropertyVisible(StatescriptPropertyDirection direction, int propertyIndex)
+	{
+		if (NodeResource is null)
+		{
+			return;
+		}
+
+		if (direction == StatescriptPropertyDirection.Input)
+		{
+			SetFoldState(FoldInputKey, false);
+			SetFoldState(GetInputPropertyFoldKey(propertyIndex), false);
+		}
+		else
+		{
+			SetFoldState(FoldOutputKey, false);
+		}
 	}
 
 	private void FlushInputPropertyConfig(int propertyIndex)
@@ -766,23 +807,25 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		// Changing an input's type/shape invalidates its resolver, so the binding is reset (passing a Nil resolver).
 		ApplyInputPropertyConfig(newData, propertyIndex, default);
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction(pending.ActionName, customContext: _graph);
-			_undoRedo.AddDoMethod(
-				this,
-				MethodName.ApplyInputPropertyConfig,
-				newData,
-				propertyIndex,
-				Variant.From((StatescriptResolverResource?)null));
-			_undoRedo.AddUndoMethod(
-				this,
-				MethodName.ApplyInputPropertyConfig,
-				oldData,
-				propertyIndex,
-				Variant.From(oldResolver));
-			_undoRedo.CommitAction(false);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			pending.ActionName,
+			_graph,
+			undo =>
+			{
+				undo.AddDoMethod(
+					this,
+					MethodName.ApplyInputPropertyConfig,
+					newData,
+					propertyIndex,
+					Variant.From((StatescriptResolverResource?)null));
+				undo.AddUndoMethod(
+					this,
+					MethodName.ApplyInputPropertyConfig,
+					oldData,
+					propertyIndex,
+					Variant.From(oldResolver));
+			});
 
 		PropertyBindingChanged?.Invoke();
 	}
@@ -812,6 +855,7 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 				resolverVariant.AsGodotObject() as StatescriptResolverResource;
 		}
 
+		EnsurePropertyVisible(StatescriptPropertyDirection.Input, propertyIndex);
 		NotifyGraphResourceChanged();
 		RebuildNode();
 	}
@@ -832,12 +876,15 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		EditorUndoRedoManager? savedUndoRedo = _undoRedo;
 		Initialize(NodeResource, _graph);
 		_undoRedo = savedUndoRedo;
-		Size = new Vector2(Size.X, 0);
+
+		// Re-fit to the freshly rebuilt content (respecting the floor) rather than preserving the previous width.
+		ResetSize();
 	}
 
 	private void RefreshHighlightState()
 	{
-		_isHighlighted = (!string.IsNullOrEmpty(_highlightedVariableName) && ReferencesVariable(_highlightedVariableName))
+		_isHighlighted = (!string.IsNullOrEmpty(_highlightedVariableName)
+			&& ReferencesVariable(_highlightedVariableName))
 			|| ReferencesSharedVariable(_highlightedSharedVariableSetPath, _highlightedSharedVariableName);
 		ApplyHighlightBorder();
 		UpdateChildHighlights();

--- a/addons/forge/editor/statescript/StatescriptGraphNode.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using Gamesmiths.Forge.Godot.Resources.Statescript;
 using Godot;
+using GodotCollections = Godot.Collections;
 
 namespace Gamesmiths.Forge.Godot.Editor.Statescript;
 
@@ -36,6 +37,7 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 	private readonly Dictionary<PropertySlotKey, NodeEditorProperty> _activeResolverEditors = [];
 	private readonly Dictionary<FoldableContainer, string> _foldableKeys = [];
 	private readonly Dictionary<PropertySlotKey, InputPropertyFoldableContext> _inputPropertyFoldables = [];
+	private readonly Dictionary<int, PendingInputConfig> _pendingInputConfigs = [];
 
 	private int[] _visualToRuntimeOutputPortMap = [];
 	private int[] _runtimeToVisualOutputPortMap = [];
@@ -168,6 +170,7 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		_inputPropertyContexts.Clear();
 		_foldableKeys.Clear();
 		_inputPropertyFoldables.Clear();
+		_pendingInputConfigs.Clear();
 
 		_activeCustomEditor?.Unbind();
 		_activeCustomEditor = null;
@@ -199,10 +202,10 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		StatescriptNodeDiscovery.InputPropertyInfo propInfo,
 		int index,
 		Control container,
-		Action<bool>? onShapeChanged = null,
+		string? shapeCustomDataKey = null,
 		string? preferredDefaultResolverTypeId = null)
 	{
-		AddInputPropertyRow(propInfo, index, container, onShapeChanged, preferredDefaultResolverTypeId);
+		AddInputPropertyRow(propInfo, index, container, shapeCustomDataKey, preferredDefaultResolverTypeId);
 	}
 
 	internal void AddOutputVariableRowInternal(
@@ -306,6 +309,44 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		UpdateInputPropertyFoldableTitles();
 	}
 
+	/// <summary>
+	/// Requests an input-property type/shape change for a single slot with full undo/redo support.
+	/// </summary>
+	/// <remarks>
+	/// This is the single entry point used both by standard shape dropdowns (wired automatically in
+	/// <see cref="AddInputPropertyRow"/>) and by custom dropdowns in node editors (via
+	/// <see cref="CustomNodeEditor.ChangeInputPropertyConfig"/>). The actual mutation is deferred so the dropdown that
+	/// emitted the change is not freed mid-signal by the node rebuild, and repeated changes to the same slot within a
+	/// frame are coalesced into a single undo action.
+	/// </remarks>
+	/// <param name="propertyIndex">The input slot whose configuration changes.</param>
+	/// <param name="customData">The CustomData entries to store (e.g. value type and/or array shape).</param>
+	/// <param name="actionName">The undo/redo action label.</param>
+	internal void ChangeInputPropertyConfigInternal(
+		int propertyIndex,
+		GodotCollections.Dictionary customData,
+		string actionName)
+	{
+		if (NodeResource is null)
+		{
+			return;
+		}
+
+		// Merge into any change already queued for this slot this frame so none is lost before the deferred flush.
+		if (_pendingInputConfigs.TryGetValue(propertyIndex, out PendingInputConfig? pending))
+		{
+			foreach (KeyValuePair<Variant, Variant> entry in customData)
+			{
+				pending.CustomData[entry.Key] = entry.Value;
+			}
+
+			return;
+		}
+
+		_pendingInputConfigs[propertyIndex] = new PendingInputConfig(customData, actionName);
+		CallDeferred(MethodName.FlushInputPropertyConfig, propertyIndex);
+	}
+
 	private static string GetResolverTypeId(StatescriptResolverResource resolver)
 	{
 		return resolver.ResolverTypeId;
@@ -316,13 +357,28 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		foreach (Node child in container.GetChildren())
 		{
 			container.RemoveChild(child);
-			child.Free();
+			child.QueueFree();
 		}
 	}
 
 	private static string GetInputPropertyFoldKey(int propertyIndex)
 	{
 		return $"{FoldInputPropertyKeyPrefix}{propertyIndex}";
+	}
+
+	private static bool VariantEquals(Variant a, Variant b)
+	{
+		if (a.VariantType != b.VariantType)
+		{
+			return false;
+		}
+
+		return a.VariantType switch
+		{
+			Variant.Type.Bool => a.AsBool() == b.AsBool(),
+			Variant.Type.Int => a.AsInt64() == b.AsInt64(),
+			_ => a.AsString() == b.AsString(),
+		};
 	}
 
 	private void SetupFromTypeInfo(StatescriptNodeDiscovery.NodeTypeInfo typeInfo)
@@ -673,6 +729,93 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		RebuildNode();
 	}
 
+	private void FlushInputPropertyConfig(int propertyIndex)
+	{
+		if (!_pendingInputConfigs.Remove(propertyIndex, out PendingInputConfig? pending) || NodeResource is null)
+		{
+			return;
+		}
+
+		GodotCollections.Dictionary newData = pending.CustomData;
+
+		// Snapshot the current values of exactly the keys being changed so they can be restored on undo, and detect
+		// whether anything actually changes (dropdowns can re-emit the already-selected value).
+		var oldData = new GodotCollections.Dictionary();
+		bool changed = false;
+
+		foreach (KeyValuePair<Variant, Variant> entry in newData)
+		{
+			string key = entry.Key.AsString();
+			bool had = NodeResource.CustomData.TryGetValue(key, out Variant existing);
+			oldData[key] = had ? existing : default;
+
+			if (!had || !VariantEquals(existing, entry.Value))
+			{
+				changed = true;
+			}
+		}
+
+		if (!changed)
+		{
+			return;
+		}
+
+		var oldResolver = FindBinding(StatescriptPropertyDirection.Input, propertyIndex)?.Resolver?.Duplicate()
+			as StatescriptResolverResource;
+
+		// Changing an input's type/shape invalidates its resolver, so the binding is reset (passing a Nil resolver).
+		ApplyInputPropertyConfig(newData, propertyIndex, default);
+
+		if (_undoRedo is not null)
+		{
+			_undoRedo.CreateAction(pending.ActionName, customContext: _graph);
+			_undoRedo.AddDoMethod(
+				this,
+				MethodName.ApplyInputPropertyConfig,
+				newData,
+				propertyIndex,
+				Variant.From((StatescriptResolverResource?)null));
+			_undoRedo.AddUndoMethod(
+				this,
+				MethodName.ApplyInputPropertyConfig,
+				oldData,
+				propertyIndex,
+				Variant.From(oldResolver));
+			_undoRedo.CommitAction(false);
+		}
+
+		PropertyBindingChanged?.Invoke();
+	}
+
+	private void ApplyInputPropertyConfig(
+		GodotCollections.Dictionary customData,
+		int propertyIndex,
+		Variant resolverVariant)
+	{
+		if (NodeResource is null)
+		{
+			return;
+		}
+
+		foreach (KeyValuePair<Variant, Variant> entry in customData)
+		{
+			NodeResource.CustomData[entry.Key.AsString()] = entry.Value;
+		}
+
+		if (resolverVariant.VariantType == Variant.Type.Nil)
+		{
+			RemoveBinding(StatescriptPropertyDirection.Input, propertyIndex);
+		}
+		else
+		{
+			EnsureBinding(StatescriptPropertyDirection.Input, propertyIndex).Resolver =
+				resolverVariant.AsGodotObject() as StatescriptResolverResource;
+		}
+
+		NotifyGraphResourceChanged();
+		RebuildNode();
+	}
+
 	private void NotifyGraphResourceChanged()
 	{
 		NodeResource?.EmitChanged();
@@ -765,6 +908,8 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 			NotifyGraphResourceChanged();
 		}
 	}
+
+	private sealed record PendingInputConfig(GodotCollections.Dictionary CustomData, string ActionName);
 }
 
 /// <summary>

--- a/addons/forge/editor/statescript/StatescriptVariablePanel.UndoRedoCallbacks.cs
+++ b/addons/forge/editor/statescript/StatescriptVariablePanel.UndoRedoCallbacks.cs
@@ -14,6 +14,43 @@ internal sealed partial class StatescriptVariablePanel
 		variable.EmitChanged();
 	}
 
+	private void SetArrayElementValueWithUndo(StatescriptGraphVariable variable, int index, Variant newValue)
+	{
+		if (index < 0 || index >= variable.InitialArrayValues.Count)
+		{
+			return;
+		}
+
+		Variant oldValue = variable.InitialArrayValues[index];
+
+		SetArrayElementValue(variable, index, newValue);
+
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			$"Change Variable '{variable.VariableName}' [{index}]",
+			_graph,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.ApplyArrayElementValue, variable, index, newValue);
+				undo.AddUndoMethod(this, MethodName.ApplyArrayElementValue, variable, index, oldValue);
+			});
+	}
+
+	private void ApplyArrayElementValue(StatescriptGraphVariable variable, int index, Variant value)
+	{
+		if (index >= 0 && index < variable.InitialArrayValues.Count)
+		{
+			variable.InitialArrayValues[index] = value;
+			variable.EmitChanged();
+		}
+
+		// Reveal the changed element so an undo/redo isn't hidden inside a collapsed array.
+		EnsureArrayExpanded(variable.VariableName);
+
+		RebuildList();
+		VariableUndoRedoPerformed?.Invoke();
+	}
+
 	private void SetVariableValue(StatescriptGraphVariable variable, Variant newValue)
 	{
 		Variant oldValue = variable.InitialValue;
@@ -21,26 +58,15 @@ internal sealed partial class StatescriptVariablePanel
 		variable.InitialValue = newValue;
 		variable.EmitChanged();
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction(
-				$"Change Variable '{variable.VariableName}'",
-				customContext: _graph);
-
-			_undoRedo.AddDoMethod(
-				this,
-				MethodName.ApplyVariableValue,
-				variable,
-				newValue);
-
-			_undoRedo.AddUndoMethod(
-				this,
-				MethodName.ApplyVariableValue,
-				variable,
-				oldValue);
-
-			_undoRedo.CommitAction(false);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			$"Change Variable '{variable.VariableName}'",
+			_graph,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.ApplyVariableValue, variable, newValue);
+				undo.AddUndoMethod(this, MethodName.ApplyVariableValue, variable, oldValue);
+			});
 	}
 
 	private void ApplyVariableValue(StatescriptGraphVariable variable, Variant value)
@@ -100,8 +126,7 @@ internal sealed partial class StatescriptVariablePanel
 	{
 		variable.InitialArrayValues.Add(value);
 		variable.EmitChanged();
-		_expandedArrays.Add(variable.VariableName);
-		SaveExpandedArrayState();
+		EnsureArrayExpanded(variable.VariableName);
 		RebuildList();
 	}
 
@@ -113,6 +138,7 @@ internal sealed partial class StatescriptVariablePanel
 			variable.EmitChanged();
 		}
 
+		EnsureArrayExpanded(variable.VariableName);
 		RebuildList();
 		VariableUndoRedoPerformed?.Invoke();
 	}
@@ -136,8 +162,19 @@ internal sealed partial class StatescriptVariablePanel
 		}
 
 		variable.EmitChanged();
+		EnsureArrayExpanded(variable.VariableName);
 		RebuildList();
 		VariableUndoRedoPerformed?.Invoke();
+	}
+
+	private void EnsureArrayExpanded(string variableName)
+	{
+		// Reveal the array so an undo/redo or programmatic change isn't hidden inside a collapsed entry. This adjusts
+		// only the persisted expand state and does not record its own undo step.
+		if (_expandedArrays.Add(variableName))
+		{
+			SaveExpandedArrayState();
+		}
 	}
 
 	private void DoSetArrayExpanded(string variableName, bool expanded)

--- a/addons/forge/editor/statescript/StatescriptVariablePanel.ValueEditors.cs
+++ b/addons/forge/editor/statescript/StatescriptVariablePanel.ValueEditors.cs
@@ -77,6 +77,12 @@ internal sealed partial class StatescriptVariablePanel
 			SizeFlagsHorizontal = SizeFlags.ExpandFill,
 		};
 
+		if (variable.VariableType == StatescriptVariableType.Entity)
+		{
+			vBox.AddChild(new Label { Text = "Runtime-assigned entity references." });
+			return vBox;
+		}
+
 		var headerRow = new HBoxContainer();
 		vBox.AddChild(headerRow);
 
@@ -125,12 +131,6 @@ internal sealed partial class StatescriptVariablePanel
 		};
 
 		headerRow.AddChild(toggleButton);
-
-		if (variable.VariableType == StatescriptVariableType.Entity)
-		{
-			vBox.AddChild(new Label { Text = "Runtime-assigned entity references." });
-			return vBox;
-		}
 
 		var addElementButton = new Button
 		{

--- a/addons/forge/editor/statescript/StatescriptVariablePanel.ValueEditors.cs
+++ b/addons/forge/editor/statescript/StatescriptVariablePanel.ValueEditors.cs
@@ -113,21 +113,15 @@ internal sealed partial class StatescriptVariablePanel
 
 			SaveExpandedArrayState();
 
-			if (_undoRedo is not null)
-			{
-				_undoRedo.CreateAction("Toggle Array Expand", customContext: _graph);
-				_undoRedo.AddDoMethod(
-					this,
-					MethodName.DoSetArrayExpanded,
-					variable.VariableName,
-					x);
-				_undoRedo.AddUndoMethod(
-					this,
-					MethodName.DoSetArrayExpanded,
-					variable.VariableName,
-					wasExpanded);
-				_undoRedo.CommitAction(false);
-			}
+			EditorUndoRedoUtils.Record(
+				_undoRedo,
+				"Toggle Array Expand",
+				_graph,
+				undo =>
+				{
+					undo.AddDoMethod(this, MethodName.DoSetArrayExpanded, variable.VariableName, x);
+					undo.AddUndoMethod(this, MethodName.DoSetArrayExpanded, variable.VariableName, wasExpanded);
+				});
 		};
 
 		headerRow.AddChild(toggleButton);
@@ -151,24 +145,17 @@ internal sealed partial class StatescriptVariablePanel
 			Variant defaultValue =
 				StatescriptVariableTypeConverter.CreateDefaultGodotVariant(variable.VariableType);
 
-			if (_undoRedo is not null)
-			{
-				_undoRedo.CreateAction("Add Array Element", customContext: _graph);
-				_undoRedo.AddDoMethod(
-					this,
-					MethodName.DoAddArrayElement,
-					variable,
-					defaultValue);
-				_undoRedo.AddUndoMethod(
-					this,
-					MethodName.UndoAddArrayElement,
-					variable);
-				_undoRedo.CommitAction();
-			}
-			else
-			{
-				DoAddArrayElement(variable, defaultValue);
-			}
+			EditorUndoRedoUtils.Record(
+				_undoRedo,
+				"Add Array Element",
+				_graph,
+				undo =>
+				{
+					undo.AddDoMethod(this, MethodName.DoAddArrayElement, variable, defaultValue);
+					undo.AddUndoMethod(this, MethodName.UndoAddArrayElement, variable);
+				},
+				execute: true,
+				fallback: () => DoAddArrayElement(variable, defaultValue));
 		};
 
 		headerRow.AddChild(addElementButton);
@@ -187,7 +174,7 @@ internal sealed partial class StatescriptVariablePanel
 
 				elementRow.AddChild(StatescriptEditorControls.CreateBoolEditor(
 					variable.InitialArrayValues[i].AsBool(),
-					x => SetArrayElementValue(
+					x => SetArrayElementValueWithUndo(
 						variable,
 						capturedIndex,
 						Variant.From(x))));
@@ -220,7 +207,7 @@ internal sealed partial class StatescriptVariablePanel
 						Variant newValue = StatescriptEditorControls.BuildVectorVariant(
 							variable.VariableType,
 							x);
-						SetArrayElementValue(variable, capturedIndex, newValue);
+						SetArrayElementValueWithUndo(variable, capturedIndex, newValue);
 					});
 
 				elementVBox.AddChild(vectorEditor);
@@ -239,7 +226,7 @@ internal sealed partial class StatescriptVariablePanel
 						Variant newValue = StatescriptEditorControls.IsIntegerType(variable.VariableType)
 							? Variant.From((long)x)
 							: Variant.From(x);
-						SetArrayElementValue(variable, capturedIndex, newValue);
+						SetArrayElementValueWithUndo(variable, capturedIndex, newValue);
 					});
 
 				elementRow.AddChild(elementSpin);
@@ -264,28 +251,19 @@ internal sealed partial class StatescriptVariablePanel
 
 		removeElementButton.Pressed += () =>
 		{
-			if (_undoRedo is not null)
-			{
-				Variant removedValue = variable.InitialArrayValues[elementIndex];
+			Variant removedValue = variable.InitialArrayValues[elementIndex];
 
-				_undoRedo.CreateAction("Remove Array Element", customContext: _graph);
-				_undoRedo.AddDoMethod(
-					this,
-					MethodName.DoRemoveArrayElement,
-					variable,
-					elementIndex);
-				_undoRedo.AddUndoMethod(
-					this,
-					MethodName.UndoRemoveArrayElement,
-					variable,
-					elementIndex,
-					removedValue);
-				_undoRedo.CommitAction();
-			}
-			else
-			{
-				DoRemoveArrayElement(variable, elementIndex);
-			}
+			EditorUndoRedoUtils.Record(
+				_undoRedo,
+				"Remove Array Element",
+				_graph,
+				undo =>
+				{
+					undo.AddDoMethod(this, MethodName.DoRemoveArrayElement, variable, elementIndex);
+					undo.AddUndoMethod(this, MethodName.UndoRemoveArrayElement, variable, elementIndex, removedValue);
+				},
+				execute: true,
+				fallback: () => DoRemoveArrayElement(variable, elementIndex));
 		};
 
 		row.AddChild(removeElementButton);

--- a/addons/forge/editor/statescript/StatescriptVariablePanel.cs
+++ b/addons/forge/editor/statescript/StatescriptVariablePanel.cs
@@ -540,17 +540,17 @@ internal sealed partial class StatescriptVariablePanel : VBoxContainer, ISeriali
 			InitialValue = StatescriptVariableTypeConverter.CreateDefaultGodotVariant(varType),
 		};
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction("Add Graph Variable", customContext: _graph);
-			_undoRedo.AddDoMethod(this, MethodName.DoAddVariable, _graph, newVariable);
-			_undoRedo.AddUndoMethod(this, MethodName.UndoAddVariable, _graph, newVariable);
-			_undoRedo.CommitAction();
-		}
-		else
-		{
-			DoAddVariable(_graph, newVariable);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			"Add Graph Variable",
+			_graph,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.DoAddVariable, _graph, newVariable);
+				undo.AddUndoMethod(this, MethodName.UndoAddVariable, _graph, newVariable);
+			},
+			execute: true,
+			fallback: () => DoAddVariable(_graph, newVariable));
 
 		_creationDialog?.QueueFree();
 		_creationDialog = null;
@@ -568,17 +568,17 @@ internal sealed partial class StatescriptVariablePanel : VBoxContainer, ISeriali
 
 		StatescriptGraphVariable variable = _graph.Variables[index];
 
-		if (_undoRedo is not null)
-		{
-			_undoRedo.CreateAction("Remove Graph Variable", customContext: _graph);
-			_undoRedo.AddDoMethod(this, MethodName.DoRemoveVariable, _graph, variable, index);
-			_undoRedo.AddUndoMethod(this, MethodName.UndoRemoveVariable, _graph, variable, index);
-			_undoRedo.CommitAction();
-		}
-		else
-		{
-			DoRemoveVariable(_graph, variable, index);
-		}
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			"Remove Graph Variable",
+			_graph,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.DoRemoveVariable, _graph, variable, index);
+				undo.AddUndoMethod(this, MethodName.UndoRemoveVariable, _graph, variable, index);
+			},
+			execute: true,
+			fallback: () => DoRemoveVariable(_graph, variable, index));
 	}
 
 	private void ClearReferencesToVariable(string variableName)

--- a/addons/forge/editor/statescript/node_editors/DebugNodeEditor.cs
+++ b/addons/forge/editor/statescript/node_editors/DebugNodeEditor.cs
@@ -4,6 +4,7 @@
 using System;
 using Gamesmiths.Forge.Godot.Resources.Statescript;
 using Godot;
+using GodotCollections = Godot.Collections;
 
 namespace Gamesmiths.Forge.Godot.Editor.Statescript.NodeEditors;
 
@@ -25,12 +26,6 @@ internal sealed partial class DebugNodeEditor : CustomNodeEditor
 	private VBoxContainer? _inputRootContainer;
 
 	[NonSerialized]
-	private VBoxContainer? _inputEditorContainer;
-
-	[NonSerialized]
-	private StatescriptNodeDiscovery.NodeTypeInfo? _cachedTypeInfo;
-
-	[NonSerialized]
 	private FoldableContainer? _typeFoldable;
 
 	/// <inheritdoc/>
@@ -39,8 +34,6 @@ internal sealed partial class DebugNodeEditor : CustomNodeEditor
 	/// <inheritdoc/>
 	public override void BuildPropertySections(StatescriptNodeDiscovery.NodeTypeInfo typeInfo)
 	{
-		_cachedTypeInfo = typeInfo;
-
 		if (NodeResource.CustomData.TryGetValue(ValueTypeKey, out Variant storedType))
 		{
 			_selectedType = (StatescriptVariableType)storedType.AsInt32();
@@ -74,8 +67,6 @@ internal sealed partial class DebugNodeEditor : CustomNodeEditor
 	{
 		base.Unbind();
 		_inputRootContainer = null;
-		_inputEditorContainer = null;
-		_cachedTypeInfo = null;
 		_typeFoldable = null;
 	}
 
@@ -118,10 +109,10 @@ internal sealed partial class DebugNodeEditor : CustomNodeEditor
 			return;
 		}
 
-		NodeResource.CustomData[ValueTypeKey] = Variant.From((int)selectedValue);
-		_selectedType = selectedValue;
-		NotifyGraphResourceChanged();
-		RefreshTypedInputEditor();
+		ChangeInputPropertyConfig(
+			0,
+			new GodotCollections.Dictionary { { ValueTypeKey, (int)selectedValue } },
+			"Change Debug Input Type");
 	}
 
 	private void OnShapeChanged(bool isArray)
@@ -131,10 +122,10 @@ internal sealed partial class DebugNodeEditor : CustomNodeEditor
 			return;
 		}
 
-		NodeResource.CustomData[IsArrayKey] = Variant.From(isArray);
-		_selectedIsArray = isArray;
-		NotifyGraphResourceChanged();
-		RefreshTypedInputEditor();
+		ChangeInputPropertyConfig(
+			0,
+			new GodotCollections.Dictionary { { IsArrayKey, isArray } },
+			"Change Debug Input Shape");
 	}
 
 	private void OnTypeFoldableFoldingChanged(bool folded)
@@ -168,29 +159,10 @@ internal sealed partial class DebugNodeEditor : CustomNodeEditor
 
 		ClearValueRows();
 		Type clrType = StatescriptVariableTypeConverter.ToSystemType(_selectedType);
-		_inputEditorContainer = _inputRootContainer;
 		AddInputPropertyRow(
 			new StatescriptNodeDiscovery.InputPropertyInfo(originalInfo.Label, clrType, _selectedIsArray),
 			0,
-			_inputEditorContainer);
-	}
-
-	private void RefreshTypedInputEditor()
-	{
-		UpdateTypeFoldableTitle();
-
-		RemoveBinding(StatescriptPropertyDirection.Input, 0);
-		ActiveResolverEditors.Remove(new PropertySlotKey(StatescriptPropertyDirection.Input, 0));
-
-		if (_cachedTypeInfo is not null
-			&& _inputEditorContainer is not null
-			&& _cachedTypeInfo.InputPropertiesInfo.Length > 0)
-		{
-			RebuildInputEditor(_cachedTypeInfo.InputPropertiesInfo[0]);
-		}
-
-		RaisePropertyBindingChanged();
-		ResetSize();
+			_inputRootContainer);
 	}
 
 	private void ClearValueRows()
@@ -208,7 +180,7 @@ internal sealed partial class DebugNodeEditor : CustomNodeEditor
 			}
 
 			_inputRootContainer.RemoveChild(child);
-			child.Free();
+			child.QueueFree();
 		}
 	}
 }

--- a/addons/forge/editor/statescript/node_editors/EffectApplicationNodeEditorBase.cs
+++ b/addons/forge/editor/statescript/node_editors/EffectApplicationNodeEditorBase.cs
@@ -19,6 +19,7 @@ internal abstract partial class EffectApplicationNodeEditorBase : CustomNodeEdit
 
 	[NonSerialized]
 	private VBoxContainer? _inputEditorsContainer;
+
 	private bool _effectIsArray;
 	private bool _targetIsArray;
 
@@ -73,40 +74,6 @@ internal abstract partial class EffectApplicationNodeEditorBase : CustomNodeEdit
 		};
 	}
 
-	private void OnEffectShapeChanged(bool isArray)
-	{
-		if (_effectIsArray == isArray)
-		{
-			return;
-		}
-
-		_effectIsArray = isArray;
-		NodeResource.CustomData[EffectIsArrayKey] = Variant.From(isArray);
-		NotifyGraphResourceChanged();
-		RemoveBinding(StatescriptPropertyDirection.Input, 0);
-		ActiveResolverEditors.Remove(new PropertySlotKey(StatescriptPropertyDirection.Input, 0));
-		RebuildInputEditors();
-		RaisePropertyBindingChanged();
-		ResetSize();
-	}
-
-	private void OnTargetShapeChanged(bool isArray)
-	{
-		if (_targetIsArray == isArray)
-		{
-			return;
-		}
-
-		_targetIsArray = isArray;
-		NodeResource.CustomData[TargetIsArrayKey] = Variant.From(isArray);
-		NotifyGraphResourceChanged();
-		RemoveBinding(StatescriptPropertyDirection.Input, 1);
-		ActiveResolverEditors.Remove(new PropertySlotKey(StatescriptPropertyDirection.Input, 1));
-		RebuildInputEditors();
-		RaisePropertyBindingChanged();
-		ResetSize();
-	}
-
 	private void RebuildInputEditors()
 	{
 		if (_cachedTypeInfo is null || _inputEditorsContainer is null || _cachedTypeInfo.InputPropertiesInfo.Length < 2)
@@ -131,7 +98,7 @@ internal abstract partial class EffectApplicationNodeEditorBase : CustomNodeEdit
 				_effectIsArray),
 			0,
 			_inputEditorsContainer,
-			OnEffectShapeChanged);
+			EffectIsArrayKey);
 		AddInputPropertyRow(
 			new StatescriptNodeDiscovery.InputPropertyInfo(
 				targetInfo.Label,
@@ -139,7 +106,7 @@ internal abstract partial class EffectApplicationNodeEditorBase : CustomNodeEdit
 				_targetIsArray),
 			1,
 			_inputEditorsContainer,
-			OnTargetShapeChanged);
+			TargetIsArrayKey);
 
 		for (int i = 2; i < _cachedTypeInfo.InputPropertiesInfo.Length; i++)
 		{

--- a/addons/forge/editor/statescript/resolvers/bases/NestedResolverEditorUtilities.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/NestedResolverEditorUtilities.cs
@@ -55,7 +55,7 @@ internal static class NestedResolverEditorUtilities
 		foreach (Node child in container.GetChildren())
 		{
 			container.RemoveChild(child);
-			child.Free();
+			child.QueueFree();
 		}
 	}
 

--- a/addons/forge/editor/tags/TagsEditorDock.cs
+++ b/addons/forge/editor/tags/TagsEditorDock.cs
@@ -23,6 +23,8 @@ public partial class TagsEditorDock : EditorDock, ISerializationListener
 
 	private ForgeData? _forgePluginData;
 
+	private EditorUndoRedoManager? _undoRedo;
+
 	private Tree? _tree;
 	private LineEdit? _tagNameTextField;
 	private Button? _addTagButton;
@@ -35,6 +37,15 @@ public partial class TagsEditorDock : EditorDock, ISerializationListener
 		Title = "Tags";
 		DockIcon = GD.Load<Texture2D>("uid://cu6ncpuumjo20");
 		DefaultSlot = DockSlot.RightUl;
+	}
+
+	/// <summary>
+	/// Sets the <see cref="EditorUndoRedoManager"/> used for undo/redo support.
+	/// </summary>
+	/// <param name="undoRedo">The undo/redo manager from the editor plugin.</param>
+	public void SetUndoRedo(EditorUndoRedoManager undoRedo)
+	{
+		_undoRedo = undoRedo;
 	}
 
 	public override void _Ready()
@@ -151,10 +162,10 @@ public partial class TagsEditorDock : EditorDock, ISerializationListener
 			return;
 		}
 
-		_forgePluginData.RegisteredTags.Add(_tagNameTextField.Text);
-		ResourceSaver.Save(_forgePluginData);
+		string[] oldTags = [.. _forgePluginData.RegisteredTags];
+		string[] newTags = [.. oldTags, _tagNameTextField.Text];
 
-		ReconstructTreeNode();
+		RecordRegisteredTagsChange($"Add Tag '{_tagNameTextField.Text}'", oldTags, newTags);
 	}
 
 	private void ReconstructTreeNode()
@@ -224,27 +235,55 @@ public partial class TagsEditorDock : EditorDock, ISerializationListener
 			{
 				TagNode selectedTag = _treeItemToNode[item];
 
-				for (int i = _forgePluginData.RegisteredTags.Count - 1; i >= 0; i--)
+				string[] oldTags = [.. _forgePluginData.RegisteredTags];
+				var newTags = new List<string>(oldTags);
+
+				for (int i = newTags.Count - 1; i >= 0; i--)
 				{
-					string tag = _forgePluginData.RegisteredTags[i];
+					string tag = newTags[i];
 
 					if (string.Equals(tag, selectedTag.CompleteTagKey, StringComparison.OrdinalIgnoreCase) ||
 						tag.StartsWith(selectedTag.CompleteTagKey + ".", StringComparison.InvariantCultureIgnoreCase))
 					{
-						_forgePluginData.RegisteredTags.Remove(tag);
+						newTags.RemoveAt(i);
 					}
 				}
 
 				if (selectedTag.ParentTagNode is not null
-					&& !_forgePluginData.RegisteredTags.Contains(selectedTag.ParentTagNode.CompleteTagKey))
+					&& !newTags.Contains(selectedTag.ParentTagNode.CompleteTagKey))
 				{
-					_forgePluginData.RegisteredTags.Add(selectedTag.ParentTagNode.CompleteTagKey);
+					newTags.Add(selectedTag.ParentTagNode.CompleteTagKey);
 				}
 
-				ResourceSaver.Save(_forgePluginData);
-				ReconstructTreeNode();
+				RecordRegisteredTagsChange($"Remove Tag '{selectedTag.CompleteTagKey}'", oldTags, [.. newTags]);
 			}
 		}
+	}
+
+	private void RecordRegisteredTagsChange(string actionName, string[] oldTags, string[] newTags)
+	{
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			actionName,
+			_forgePluginData,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.ApplyRegisteredTags, newTags);
+				undo.AddUndoMethod(this, MethodName.ApplyRegisteredTags, oldTags);
+			},
+			execute: true,
+			fallback: () => ApplyRegisteredTags(newTags));
+	}
+
+	private void ApplyRegisteredTags(string[] tags)
+	{
+		EnsureInitialized();
+
+		_forgePluginData.RegisteredTags.Clear();
+		_forgePluginData.RegisteredTags.AddRange(tags);
+		ResourceSaver.Save(_forgePluginData);
+
+		ReconstructTreeNode();
 	}
 
 	[MemberNotNull(nameof(_tagsManager), nameof(_tree), nameof(_tagNameTextField), nameof(_forgePluginData))]


### PR DESCRIPTION
## Changed
- Refactored undo operations into a cleaner code.

## Fixed
- Fixed undo operations not working for Input properties "shapes" (single/array).
- Fixed leaked RIDs when quitting Godot.