### PR TITLE
Improved Statescript's dock theme coloring.

### DIFF
--- a/addons/forge/editor/attributes/AttributeSetValuesEditorProperty.cs
+++ b/addons/forge/editor/attributes/AttributeSetValuesEditorProperty.cs
@@ -146,7 +146,7 @@ public partial class AttributeSetValuesEditorProperty : EditorProperty, ISeriali
 
 		var style = new StyleBoxFlat
 		{
-			BgColor = new Color(0.16f, 0.17f, 0.20f),
+			BgColor = EditorInterface.Singleton.GetEditorTheme().GetColor("dark_color_2", "Editor"),
 		};
 
 		headerPanel.AddThemeStyleboxOverride("panel", style);

--- a/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
+++ b/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
@@ -24,7 +24,6 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 	private const string VariableNameButtonMetaKey = "_shared_variable_name_button";
 
 	private static readonly Color _variableColor = new(0xe5c07bff);
-	private static readonly Color _highlightColor = new(0x56b6c2ff);
 
 	private readonly HashSet<string> _expandedArrays = [];
 
@@ -165,7 +164,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 	private static void UpdateVariableNameButtonAppearance(Button button, bool isSelected)
 	{
-		Color buttonColor = isSelected ? _highlightColor : _variableColor;
+		Color highlightColor = StatescriptEditorControls.GetHighlightColor();
+		Color buttonColor = isSelected ? highlightColor : _variableColor;
 		button.AddThemeColorOverride("font_color", buttonColor);
 		button.AddThemeColorOverride("font_pressed_color", buttonColor);
 		button.AddThemeColorOverride("font_hover_color", buttonColor.Lightened(0.2f));

--- a/addons/forge/editor/statescript/StatescriptEditorControls.cs
+++ b/addons/forge/editor/statescript/StatescriptEditorControls.cs
@@ -53,6 +53,15 @@ internal static partial class StatescriptEditorControls
 	}
 
 	/// <summary>
+	/// Returns the editor's configured accent color, used to highlight the selected variable (and the nodes that
+	/// reference it) in the variable panels and the graph.
+	/// </summary>
+	public static Color GetHighlightColor()
+	{
+		return EditorInterface.Singleton.GetEditorTheme().GetColor("accent_color", "Editor");
+	}
+
+	/// <summary>
 	/// Creates a <see cref="PanelContainer"/> wrapping a <see cref="CheckBox"/> for boolean editing.
 	/// </summary>
 	/// <param name="value">The initial value of the boolean.</param>

--- a/addons/forge/editor/statescript/StatescriptEditorControls.cs
+++ b/addons/forge/editor/statescript/StatescriptEditorControls.cs
@@ -18,8 +18,6 @@ internal static partial class StatescriptEditorControls
 	private static readonly Color _axisZColor = new(0.33f, 0.55f, 0.96f);
 	private static readonly Color _axisWColor = new(0.66f, 0.66f, 0.66f);
 
-	private static StyleBox? _cachedPanelStyle;
-
 	/// <summary>
 	/// Returns <see langword="true"/> for integer-like variable types.
 	/// </summary>
@@ -606,14 +604,10 @@ internal static partial class StatescriptEditorControls
 
 	private static StyleBox GetPanelStyle()
 	{
-		if (_cachedPanelStyle is null || !GodotObject.IsInstanceValid(_cachedPanelStyle))
-		{
-			Control baseControl = EditorInterface.Singleton.GetBaseControl();
-			_cachedPanelStyle = (StyleBox)baseControl.GetThemeStylebox("normal", "LineEdit").Duplicate();
-			_cachedPanelStyle.SetContentMarginAll(0);
-		}
-
-		return _cachedPanelStyle;
+		Control baseControl = EditorInterface.Singleton.GetBaseControl();
+		var panelStyle = (StyleBox)baseControl.GetThemeStylebox("normal", "LineEdit").Duplicate();
+		panelStyle.SetContentMarginAll(0);
+		return panelStyle;
 	}
 
 	private static void UpdateValueShapeDropdownTooltip(OptionButton dropdown)

--- a/addons/forge/editor/statescript/StatescriptGraphNode.Highlighting.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.Highlighting.cs
@@ -157,13 +157,14 @@ public partial class StatescriptGraphNode
 		if (_isHighlighted)
 		{
 			StyleBoxFlat baseStyle = _basePanelStyle;
+			Color highlightColor = StatescriptEditorControls.GetHighlightColor();
 			var highlightStyle = (StyleBoxFlat)baseStyle.Duplicate();
-			highlightStyle.BorderColor = _highlightColor;
+			highlightStyle.BorderColor = highlightColor;
 			highlightStyle.BorderWidthTop = 2;
 			highlightStyle.BorderWidthBottom = 2;
 			highlightStyle.BorderWidthLeft = 2;
 			highlightStyle.BorderWidthRight = 2;
-			highlightStyle.BgColor = baseStyle.BgColor.Lerp(_highlightColor, 0.15f);
+			highlightStyle.BgColor = baseStyle.BgColor.Lerp(highlightColor, 0.15f);
 
 			AddThemeStyleboxOverride("panel", highlightStyle);
 			AddThemeStyleboxOverride("panel_selected", highlightStyle);
@@ -259,8 +260,9 @@ public partial class StatescriptGraphNode
 
 		if (isMatch)
 		{
+			Color highlightColor = StatescriptEditorControls.GetHighlightColor();
 			var highlightStyle = (StyleBoxFlat)baseStyle.Duplicate();
-			highlightStyle.BgColor = baseStyle.BgColor.Lerp(_highlightColor, 0.25f);
+			highlightStyle.BgColor = baseStyle.BgColor.Lerp(highlightColor, 0.25f);
 			dropdown.AddThemeStyleboxOverride("normal", highlightStyle);
 		}
 		else
@@ -311,7 +313,7 @@ public partial class StatescriptGraphNode
 
 		if (label.Text == _highlightedVariableName)
 		{
-			label.AddThemeColorOverride("font_color", _highlightColor);
+			label.AddThemeColorOverride("font_color", StatescriptEditorControls.GetHighlightColor());
 			label.SetMeta("is_highlight_colored", true);
 		}
 		else if (label.HasMeta("is_highlight_colored"))
@@ -379,8 +381,9 @@ public partial class StatescriptGraphNode
 			style.BorderWidthTop = Math.Max(style.BorderWidthTop, 2);
 			style.BorderWidthRight = Math.Max(style.BorderWidthRight, 2);
 			style.BorderWidthBottom = Math.Max(style.BorderWidthBottom, 2);
-			style.BorderColor = _highlightColor;
-			style.BgColor = _highlightColor;
+			Color highlightColor = StatescriptEditorControls.GetHighlightColor();
+			style.BorderColor = highlightColor;
+			style.BgColor = highlightColor;
 			iconLabel.AddThemeColorOverride("font_color", Colors.Black);
 			textLabel.AddThemeColorOverride("font_color", Colors.Black);
 		}

--- a/addons/forge/editor/statescript/StatescriptGraphNode.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.cs
@@ -32,7 +32,6 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 	private static readonly Color _subgraphColor = new(0xc678ddff);
 	private static readonly Color _inputPropertyColor = new(0x61afefff);
 	private static readonly Color _outputVariableColor = new(0xe5c07bff);
-	private static readonly Color _highlightColor = new(0x56b6c2ff);
 
 	private readonly Dictionary<PropertySlotKey, NodeEditorProperty> _activeResolverEditors = [];
 	private readonly Dictionary<FoldableContainer, string> _foldableKeys = [];

--- a/addons/forge/editor/statescript/StatescriptVariablePanel.cs
+++ b/addons/forge/editor/statescript/StatescriptVariablePanel.cs
@@ -24,7 +24,6 @@ internal sealed partial class StatescriptVariablePanel : VBoxContainer, ISeriali
 	private const string VariableNameButtonMetaKey = "_variable_name_button";
 
 	private static readonly Color _variableColor = new(0xe5c07bff);
-	private static readonly Color _highlightColor = new(0x56b6c2ff);
 
 	private readonly HashSet<string> _expandedArrays = [];
 
@@ -213,11 +212,12 @@ internal sealed partial class StatescriptVariablePanel : VBoxContainer, ISeriali
 
 	private static void UpdateVariableNameButtonAppearance(Button button, bool isSelected)
 	{
-		Color buttonColor = isSelected ? _highlightColor : _variableColor;
+		Color highlightColor = StatescriptEditorControls.GetHighlightColor();
+		Color buttonColor = isSelected ? highlightColor : _variableColor;
 		button.AddThemeColorOverride("font_color", buttonColor);
-		button.AddThemeColorOverride("font_pressed_color", _highlightColor);
+		button.AddThemeColorOverride("font_pressed_color", highlightColor);
 		button.AddThemeColorOverride("font_hover_color", buttonColor.Lightened(0.2f));
-		button.AddThemeColorOverride("font_hover_pressed_color", _highlightColor.Lightened(0.2f));
+		button.AddThemeColorOverride("font_hover_pressed_color", highlightColor.Lightened(0.2f));
 	}
 
 	private static VariableTypeSelection GetVariableSelection(StatescriptGraphVariable variable)

--- a/addons/forge/editor/statescript/node_editors/ExpressionNodeEditor.cs
+++ b/addons/forge/editor/statescript/node_editors/ExpressionNodeEditor.cs
@@ -55,10 +55,11 @@ internal sealed partial class ExpressionNodeEditor : CustomNodeEditor
 
 	private static StyleBoxFlat CreateFormulaStyleBox()
 	{
+		Theme editorTheme = EditorInterface.Singleton.GetEditorTheme();
 		var style = new StyleBoxFlat
 		{
-			BgColor = new Color(0x1b1e24ff),
-			BorderColor = new Color(0x2c313aff),
+			BgColor = editorTheme.GetColor("dark_color_1", "Editor"),
+			BorderColor = editorTheme.GetColor("dark_color_3", "Editor"),
 		};
 
 		style.SetBorderWidthAll(1);


### PR DESCRIPTION
## Changed
- Variable highlight color now uses the theme's configured accent color.

## Fixed
- Fixed some panels not following the configured theme colors.