### PR TITLE
Fixed wrong variables panel when a graph opens in a new tab.

### DIFF
--- a/addons/forge/editor/statescript/StatescriptGraphEditorDock.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphEditorDock.cs
@@ -263,6 +263,8 @@ public partial class StatescriptGraphEditorDock : EditorDock, ISerializationList
 
 		LoadGraphIntoEditor(graph);
 		UpdateVisibility();
+
+		ApplyVariablesPanelState(_openTabs.Count - 1);
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Description

OpenGraph called ApplyVariablesPanelState only when the graph was already open in a tab. On the new-tab path it never ran, and SetCurrentTabWithoutLoading deliberately suppresses the tab-changed handler, so nothing rebound the panel: it kept listing the previously active graph's variables until the user switched tabs away and back.

Apply the panel state on the new-tab path too. UpdateVisibility only touches the panel when no graph is open, so running it afterwards is safe.