### PR TITLE
Refactored Undo/Redo behavior for better user experience.

### DIFF
--- a/addons/forge/ForgePluginLoader.cs
+++ b/addons/forge/ForgePluginLoader.cs
@@ -174,6 +174,13 @@ public partial class ForgePluginLoader : EditorPlugin
 			_tagEditingController = null;
 		}
 
+		if (_sharedVariableSetEditingController is not null)
+		{
+			RemoveChild(_sharedVariableSetEditingController);
+			_sharedVariableSetEditingController.QueueFree();
+			_sharedVariableSetEditingController = null;
+		}
+
 		_fileSystem = null;
 		_resourcesReimportedCallable = default;
 		_resourcesReloadCallable = default;

--- a/addons/forge/ForgePluginLoader.cs
+++ b/addons/forge/ForgePluginLoader.cs
@@ -34,6 +34,7 @@ public partial class ForgePluginLoader : EditorPlugin
 	private AttributeEditorPlugin? _attributeEditorPlugin;
 	private AttributeSetDefinitionInspectorPlugin? _attributeSetDefinitionInspectorPlugin;
 	private SharedVariableSetInspectorPlugin? _sharedVariableSetInspectorPlugin;
+	private SharedVariableSetEditingController? _sharedVariableSetEditingController;
 	private StatescriptGraphEditorDock? _statescriptGraphEditorDock;
 
 	private AssetRepairDialog? _repairDialog;
@@ -79,8 +80,14 @@ public partial class ForgePluginLoader : EditorPlugin
 		AddInspectorPlugin(_attributeEditorPlugin);
 		_attributeSetDefinitionInspectorPlugin = new AttributeSetDefinitionInspectorPlugin();
 		AddInspectorPlugin(_attributeSetDefinitionInspectorPlugin);
+
+		// Same reasoning as the tag controller: it has to outlive the property editors the inspector rebuilds.
+		_sharedVariableSetEditingController = new SharedVariableSetEditingController();
+		_sharedVariableSetEditingController.SetUndoRedo(GetUndoRedo());
+		AddChild(_sharedVariableSetEditingController);
+
 		_sharedVariableSetInspectorPlugin = new SharedVariableSetInspectorPlugin();
-		_sharedVariableSetInspectorPlugin.SetUndoRedo(GetUndoRedo());
+		_sharedVariableSetInspectorPlugin.SetEditingController(_sharedVariableSetEditingController);
 		AddInspectorPlugin(_sharedVariableSetInspectorPlugin);
 
 		_statescriptGraphEditorDock = new StatescriptGraphEditorDock();

--- a/addons/forge/ForgePluginLoader.cs
+++ b/addons/forge/ForgePluginLoader.cs
@@ -46,6 +46,8 @@ public partial class ForgePluginLoader : EditorPlugin
 
 	public override void _EnterTree()
 	{
+		EditorUndoRedoUtils.ResetScopes();
+
 		ForgeSettings.EnsureRegistered();
 		EnsureTagSourceExists();
 

--- a/addons/forge/editor/EditorUndoRedoUtils.cs
+++ b/addons/forge/editor/EditorUndoRedoUtils.cs
@@ -33,6 +33,19 @@ internal static class EditorUndoRedoUtils
 	}
 
 	/// <summary>
+	/// Clears any scope left open, so a fresh plugin session never starts with recording disabled.
+	/// </summary>
+	/// <remarks>
+	/// Depth is balanced by <c>using</c>, but an assembly reload can tear down a callback mid-flight and one leaked
+	/// scope would kill undo for the rest of the session, with no symptom beyond "Ctrl+Z does nothing".
+	/// </remarks>
+	public static void ResetScopes()
+	{
+		ReplayScope.Reset();
+		ViewStateScope.Reset();
+	}
+
+	/// <summary>
 	/// Suppresses undo/redo recording for as long as the returned value is alive, while still letting the change reach
 	/// the resource.
 	/// </summary>
@@ -69,21 +82,17 @@ internal static class EditorUndoRedoUtils
 		bool execute = false,
 		Action? fallback = null)
 	{
-		if (IsReplaying)
+		if (IsReplaying || ViewStateScope.Depth > 0)
 		{
-			// Recording here would clear the redo stack and strand every action after the one being replayed. The
-			// replay itself already puts the data in the right state, so there is nothing to record.
-			return;
-		}
-
-		if (ViewStateScope.Depth > 0)
-		{
-			// View state still reaches the resource, it just does not earn an undo step.
 			return;
 		}
 
 		if (undoRedo is null)
 		{
+			// The change still lands, so warn rather than let it look like an undo bug later.
+			GD.PushWarning(
+				$"Forge: '{actionName}' was applied without undo support because no undo manager is available. " +
+				"This usually means the editor plugin was reloaded without being re-initialized; reopen the project.");
 			fallback?.Invoke();
 			return;
 		}
@@ -94,19 +103,16 @@ internal static class EditorUndoRedoUtils
 	}
 
 	/// <summary>
-	/// Scope returned by <see cref="EnterReplay"/>. Ends the replay when disposed.
+	/// Scope returned by <see cref="EnterReplay"/>.
 	/// </summary>
 	internal readonly struct ReplayScope : IDisposable
 	{
 		/// <summary>
-		/// Gets the number of replay scopes currently open. Nested scopes are expected: a replay callback may call
-		/// another one directly.
+		/// Gets the number of replay scopes currently open. Nesting is expected: a replay callback may invoke another.
 		/// </summary>
 		internal static int Depth { get; private set; }
 
-		/// <summary>
-		/// Ends the replay scope.
-		/// </summary>
+		/// <inheritdoc/>
 		public void Dispose()
 		{
 			Exit();
@@ -122,9 +128,17 @@ internal static class EditorUndoRedoUtils
 			return default;
 		}
 
+		/// <summary>
+		/// Drops any scope left open by a callback that did not unwind normally.
+		/// </summary>
+		internal static void Reset()
+		{
+			Depth = 0;
+		}
+
 		private static void Exit()
 		{
-			_depth--;
+			Depth--;
 		}
 	}
 
@@ -154,9 +168,17 @@ internal static class EditorUndoRedoUtils
 			return default;
 		}
 
+		/// <summary>
+		/// Drops any scope left open by a callback that did not unwind normally.
+		/// </summary>
+		internal static void Reset()
+		{
+			Depth = 0;
+		}
+
 		private static void Exit()
 		{
-			_depth--;
+			Depth--;
 		}
 	}
 }

--- a/addons/forge/editor/EditorUndoRedoUtils.cs
+++ b/addons/forge/editor/EditorUndoRedoUtils.cs
@@ -13,6 +13,26 @@ namespace Gamesmiths.Forge.Godot.Editor;
 internal static class EditorUndoRedoUtils
 {
 	/// <summary>
+	/// Gets a value indicating whether an undo or redo action is currently being replayed.
+	/// </summary>
+	/// <remarks>
+	/// Godot's <c>commit_action</c> clears the redo stack, so recording from inside a replay strands every action
+	/// after the one being replayed. Replay callbacks rebuild editor UI, and rebuilding re-enters code that would
+	/// otherwise record, so any such code has to check this and skip.
+	/// </remarks>
+	public static bool IsReplaying => ReplayScope.Depth > 0;
+
+	/// <summary>
+	/// Marks the calling scope as an undo/redo replay for as long as the returned value is alive. Every method
+	/// registered through <c>AddDoMethod</c> / <c>AddUndoMethod</c> should open one.
+	/// </summary>
+	/// <returns>A scope that ends the replay when disposed.</returns>
+	public static ReplayScope EnterReplay()
+	{
+		return ReplayScope.Enter();
+	}
+
+	/// <summary>
 	/// Records an undo/redo action. When <paramref name="undoRedo"/> is available, opens an action, lets
 	/// <paramref name="configure"/> register the do/undo methods, and commits it. When it is <see langword="null"/>,
 	/// the optional <paramref name="fallback"/> is invoked so the change still happens without undo support.
@@ -34,6 +54,13 @@ internal static class EditorUndoRedoUtils
 		bool execute = false,
 		Action? fallback = null)
 	{
+		if (IsReplaying)
+		{
+			// Recording here would clear the redo stack and strand every action after the one being replayed. The
+			// replay itself already puts the data in the right state, so there is nothing to record.
+			return;
+		}
+
 		if (undoRedo is null)
 		{
 			fallback?.Invoke();
@@ -43,6 +70,41 @@ internal static class EditorUndoRedoUtils
 		undoRedo.CreateAction(actionName, customContext: context);
 		configure(undoRedo);
 		undoRedo.CommitAction(execute);
+	}
+
+	/// <summary>
+	/// Scope returned by <see cref="EnterReplay"/>. Ends the replay when disposed.
+	/// </summary>
+	internal readonly struct ReplayScope : IDisposable
+	{
+		/// <summary>
+		/// Gets the number of replay scopes currently open. Nested scopes are expected: a replay callback may call
+		/// another one directly.
+		/// </summary>
+		internal static int Depth { get; private set; }
+
+		/// <summary>
+		/// Ends the replay scope.
+		/// </summary>
+		public void Dispose()
+		{
+			Exit();
+		}
+
+		/// <summary>
+		/// Opens a replay scope.
+		/// </summary>
+		/// <returns>The scope that ends the replay when disposed.</returns>
+		internal static ReplayScope Enter()
+		{
+			Depth++;
+			return default;
+		}
+
+		private static void Exit()
+		{
+			_depth--;
+		}
 	}
 }
 #endif

--- a/addons/forge/editor/EditorUndoRedoUtils.cs
+++ b/addons/forge/editor/EditorUndoRedoUtils.cs
@@ -33,6 +33,21 @@ internal static class EditorUndoRedoUtils
 	}
 
 	/// <summary>
+	/// Suppresses undo/redo recording for as long as the returned value is alive, while still letting the change reach
+	/// the resource.
+	/// </summary>
+	/// <remarks>
+	/// For view state that happens to be serialized, such as which foldable is collapsed: it belongs on disk so a
+	/// reopened graph looks the way it was left, but not on the undo stack. Neither Blender nor the Godot editor
+	/// undoes panel folding.
+	/// </remarks>
+	/// <returns>A scope that resumes recording when disposed.</returns>
+	public static ViewStateScope EnterViewStateChange()
+	{
+		return ViewStateScope.Enter();
+	}
+
+	/// <summary>
 	/// Records an undo/redo action. When <paramref name="undoRedo"/> is available, opens an action, lets
 	/// <paramref name="configure"/> register the do/undo methods, and commits it. When it is <see langword="null"/>,
 	/// the optional <paramref name="fallback"/> is invoked so the change still happens without undo support.
@@ -58,6 +73,12 @@ internal static class EditorUndoRedoUtils
 		{
 			// Recording here would clear the redo stack and strand every action after the one being replayed. The
 			// replay itself already puts the data in the right state, so there is nothing to record.
+			return;
+		}
+
+		if (ViewStateScope.Depth > 0)
+		{
+			// View state still reaches the resource, it just does not earn an undo step.
 			return;
 		}
 
@@ -96,6 +117,38 @@ internal static class EditorUndoRedoUtils
 		/// </summary>
 		/// <returns>The scope that ends the replay when disposed.</returns>
 		internal static ReplayScope Enter()
+		{
+			Depth++;
+			return default;
+		}
+
+		private static void Exit()
+		{
+			_depth--;
+		}
+	}
+
+	/// <summary>
+	/// Scope returned by <see cref="EnterViewStateChange"/>.
+	/// </summary>
+	internal readonly struct ViewStateScope : IDisposable
+	{
+		/// <summary>
+		/// Gets the number of view-state scopes currently open.
+		/// </summary>
+		internal static int Depth { get; private set; }
+
+		/// <inheritdoc/>
+		public void Dispose()
+		{
+			Exit();
+		}
+
+		/// <summary>
+		/// Opens a view-state scope.
+		/// </summary>
+		/// <returns>The scope that resumes recording when disposed.</returns>
+		internal static ViewStateScope Enter()
 		{
 			Depth++;
 			return default;

--- a/addons/forge/editor/statescript/CustomNodeEditor.cs
+++ b/addons/forge/editor/statescript/CustomNodeEditor.cs
@@ -486,8 +486,9 @@ internal abstract partial class CustomNodeEditor : RefCounted, ISerializationLis
 	/// <param name="value">The value to store.</param>
 	/// <param name="actionName">The undo/redo action label.</param>
 	/// <param name="rebuildOnChange">When <see langword="true"/>, the node's property sections are rebuilt after the
-	/// value changes (and on undo/redo), so an editor that shows or hides rows based on this config reflects the new
-	/// value immediately. Leave <see langword="false"/> for config that does not affect which rows are rendered.
+	/// user's own edit, so an editor that shows or hides rows based on this config reflects the new value immediately.
+	/// Leave <see langword="false"/> for config that does not affect which rows are rendered. This does not affect
+	/// undo/redo, which always rebuilds so the control re-reads the restored value.
 	/// </param>
 	protected void SetNodeConfig(string key, Variant value, string actionName, bool rebuildOnChange = false)
 	{

--- a/addons/forge/editor/statescript/CustomNodeEditor.cs
+++ b/addons/forge/editor/statescript/CustomNodeEditor.cs
@@ -379,8 +379,11 @@ internal abstract partial class CustomNodeEditor : RefCounted, ISerializationLis
 				? resolver.VariableName
 				: null;
 
-		// Drop a stale binding whose variable no longer matches the output's type so it is not silently kept.
-		if (!string.IsNullOrEmpty(current) && !candidates.Contains(current))
+		// Drop a stale binding whose variable no longer matches the output's type so it is not silently kept. Not
+		// during a replay, where the binding being restored is the authoritative one.
+		if (!string.IsNullOrEmpty(current)
+			&& !candidates.Contains(current)
+			&& !EditorUndoRedoUtils.IsReplaying)
 		{
 			current = null;
 			RemoveBinding(StatescriptPropertyDirection.Output, index);

--- a/addons/forge/editor/statescript/CustomNodeEditor.cs
+++ b/addons/forge/editor/statescript/CustomNodeEditor.cs
@@ -345,7 +345,7 @@ internal abstract partial class CustomNodeEditor : RefCounted, ISerializationLis
 
 		foldable.FoldingChanged += folded =>
 		{
-			SetFoldStateWithUndo(foldKey, folded);
+			PersistFoldState(foldKey, folded);
 			UpdateBadge();
 			RaisePropertyBindingChanged();
 			ResetSize();
@@ -475,9 +475,9 @@ internal abstract partial class CustomNodeEditor : RefCounted, ISerializationLis
 	/// </summary>
 	/// <param name="key">The key used to persist the fold state.</param>
 	/// <param name="folded">The new folded state.</param>
-	protected void SetFoldStateWithUndo(string key, bool folded)
+	protected void PersistFoldState(string key, bool folded)
 	{
-		_graphNode!.SetFoldStateWithUndoInternal(key, folded);
+		_graphNode!.PersistFoldStateInternal(key, folded);
 	}
 
 	/// <summary>

--- a/addons/forge/editor/statescript/NodeEditorProperty.cs
+++ b/addons/forge/editor/statescript/NodeEditorProperty.cs
@@ -146,6 +146,20 @@ internal abstract partial class NodeEditorProperty : PanelContainer
 	}
 
 	/// <summary>
+	/// Runs the editor's change callback for pure view state, writing it to the resolver without an undo step.
+	/// </summary>
+	/// <remarks>
+	/// These states are serialized inside the resolver, so the only way to persist them is the same save callback that
+	/// records edits; recording is suppressed for the call.
+	/// </remarks>
+	/// <param name="onChanged">The editor's change callback.</param>
+	protected static void SaveViewState(Action? onChanged)
+	{
+		using EditorUndoRedoUtils.ViewStateScope scope = EditorUndoRedoUtils.EnterViewStateChange();
+		onChanged?.Invoke();
+	}
+
+	/// <summary>
 	/// Notifies listeners that the editor layout has changed size.
 	/// </summary>
 	protected void RaiseLayoutSizeChanged()

--- a/addons/forge/editor/statescript/SharedVariableSetEditingController.cs
+++ b/addons/forge/editor/statescript/SharedVariableSetEditingController.cs
@@ -1,0 +1,300 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using System.Collections.Generic;
+using Gamesmiths.Forge.Godot.Resources;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Editor.Statescript;
+
+/// <summary>
+/// Hosts the undo/redo replay callbacks for shared variable set edits.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Undo targets this controller rather than the <see cref="SharedVariableSetEditorProperty"/> that made the change,
+/// because the inspector frees and rebuilds property editors constantly while the resource outlives them, and Godot's
+/// <c>UndoRedo</c> silently skips operations whose target has been freed. Actions registered on the editor stopped
+/// replaying as soon as the inspector refreshed. Mirrors <see cref="Tags.TagSourceEditingController"/>.
+/// </para>
+/// <para>
+/// Every callback mutates the resource, then refreshes whichever editors happen to be showing that set.
+/// </para>
+/// <para>
+/// A <see cref="Node"/> parented to the plugin rather than a bare <see cref="GodotObject"/>, so Godot owns its
+/// lifetime.
+/// </para>
+/// </remarks>
+[Tool]
+public sealed partial class SharedVariableSetEditingController : Node
+{
+	private readonly List<SharedVariableSetEditorProperty> _editors = [];
+
+	private EditorUndoRedoManager? _undoRedo;
+
+	/// <summary>
+	/// Sets the <see cref="EditorUndoRedoManager"/> used to record edits.
+	/// </summary>
+	/// <param name="undoRedo">The undo/redo manager from the editor plugin.</param>
+	public void SetUndoRedo(EditorUndoRedoManager? undoRedo)
+	{
+		_undoRedo = undoRedo;
+	}
+
+	/// <summary>
+	/// Applies a variable's initial value.
+	/// </summary>
+	/// <param name="set">The set owning the variable.</param>
+	/// <param name="def">The variable definition to write to.</param>
+	/// <param name="value">The value to apply.</param>
+	public void ReplayVariableValue(
+		ForgeSharedVariableSet set,
+		ForgeSharedVariableDefinition def,
+		Variant value)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		def.InitialValue = value;
+		NotifyChanged(set);
+	}
+
+	/// <summary>
+	/// Applies a single array element's value.
+	/// </summary>
+	/// <param name="set">The set owning the variable.</param>
+	/// <param name="def">The variable definition to write to.</param>
+	/// <param name="index">The element index.</param>
+	/// <param name="value">The value to apply.</param>
+	public void ReplayArrayElementValue(
+		ForgeSharedVariableSet set,
+		ForgeSharedVariableDefinition def,
+		int index,
+		Variant value)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		if (index >= 0 && index < def.InitialArrayValues.Count)
+		{
+			def.InitialArrayValues[index] = value;
+		}
+
+		NotifyChanged(set);
+	}
+
+	/// <summary>
+	/// Adds a variable definition to the set.
+	/// </summary>
+	/// <param name="set">The set to add to.</param>
+	/// <param name="def">The definition to add.</param>
+	public void ReplayAddVariable(ForgeSharedVariableSet set, ForgeSharedVariableDefinition def)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		set.Variables.Add(def);
+		NotifyChanged(set);
+	}
+
+	/// <summary>
+	/// Removes a variable definition from the set.
+	/// </summary>
+	/// <param name="set">The set to remove from.</param>
+	/// <param name="def">The definition to remove.</param>
+	public void ReplayRemoveVariable(ForgeSharedVariableSet set, ForgeSharedVariableDefinition def)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		set.Variables.Remove(def);
+		NotifyChanged(set);
+	}
+
+	/// <summary>
+	/// Re-inserts a variable definition at the position it was removed from.
+	/// </summary>
+	/// <param name="set">The set to insert into.</param>
+	/// <param name="def">The definition to insert.</param>
+	/// <param name="index">The index it previously occupied.</param>
+	public void ReplayInsertVariable(ForgeSharedVariableSet set, ForgeSharedVariableDefinition def, int index)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		if (index >= 0 && index < set.Variables.Count)
+		{
+			set.Variables.Insert(index, def);
+		}
+		else
+		{
+			set.Variables.Add(def);
+		}
+
+		NotifyChanged(set);
+	}
+
+	/// <summary>
+	/// Appends an element to a variable's initial array values, revealing the row so the change is visible.
+	/// </summary>
+	/// <param name="set">The set owning the variable.</param>
+	/// <param name="def">The variable definition to append to.</param>
+	/// <param name="value">The element value.</param>
+	public void ReplayAddArrayElement(
+		ForgeSharedVariableSet set,
+		ForgeSharedVariableDefinition def,
+		Variant value)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		def.InitialArrayValues.Add(value);
+
+		foreach (SharedVariableSetEditorProperty editor in LiveEditorsFor(set))
+		{
+			editor.SetArrayExpandedInternal(def.VariableName, expanded: true);
+		}
+
+		NotifyChanged(set);
+	}
+
+	/// <summary>
+	/// Removes the last element of a variable's initial array values, restoring the row's previous expanded state.
+	/// </summary>
+	/// <param name="set">The set owning the variable.</param>
+	/// <param name="def">The variable definition to trim.</param>
+	/// <param name="wasExpanded">Whether the row was expanded before the element was added.</param>
+	public void ReplayRemoveLastArrayElement(
+		ForgeSharedVariableSet set,
+		ForgeSharedVariableDefinition def,
+		bool wasExpanded)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		if (def.InitialArrayValues.Count > 0)
+		{
+			def.InitialArrayValues.RemoveAt(def.InitialArrayValues.Count - 1);
+		}
+
+		if (!wasExpanded)
+		{
+			foreach (SharedVariableSetEditorProperty editor in LiveEditorsFor(set))
+			{
+				editor.SetArrayExpandedInternal(def.VariableName, expanded: false);
+			}
+		}
+
+		NotifyChanged(set);
+	}
+
+	/// <summary>
+	/// Removes an element at the given index from a variable's initial array values.
+	/// </summary>
+	/// <param name="set">The set owning the variable.</param>
+	/// <param name="def">The variable definition to trim.</param>
+	/// <param name="index">The element index to remove.</param>
+	public void ReplayRemoveArrayElementAt(
+		ForgeSharedVariableSet set,
+		ForgeSharedVariableDefinition def,
+		int index)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		if (index >= 0 && index < def.InitialArrayValues.Count)
+		{
+			def.InitialArrayValues.RemoveAt(index);
+		}
+
+		NotifyChanged(set);
+	}
+
+	/// <summary>
+	/// Re-inserts an element at the position it was removed from.
+	/// </summary>
+	/// <param name="set">The set owning the variable.</param>
+	/// <param name="def">The variable definition to insert into.</param>
+	/// <param name="index">The index it previously occupied.</param>
+	/// <param name="value">The element value.</param>
+	public void ReplayInsertArrayElement(
+		ForgeSharedVariableSet set,
+		ForgeSharedVariableDefinition def,
+		int index,
+		Variant value)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		if (index >= 0 && index < def.InitialArrayValues.Count)
+		{
+			def.InitialArrayValues.Insert(index, value);
+		}
+		else
+		{
+			def.InitialArrayValues.Add(value);
+		}
+
+		NotifyChanged(set);
+	}
+
+	/// <summary>
+	/// Gets the undo/redo manager used to record edits.
+	/// </summary>
+	/// <returns>The undo/redo manager, or <see langword="null"/> when unavailable.</returns>
+	internal EditorUndoRedoManager? GetUndoRedo()
+	{
+		return _undoRedo;
+	}
+
+	/// <summary>
+	/// Registers a live editor so replays can refresh it. Editors register on entering the tree and unregister on
+	/// leaving it, so the controller never holds a freed one.
+	/// </summary>
+	/// <param name="editor">The editor to register.</param>
+	internal void RegisterEditor(SharedVariableSetEditorProperty editor)
+	{
+		if (!_editors.Contains(editor))
+		{
+			_editors.Add(editor);
+		}
+	}
+
+	/// <summary>
+	/// Unregisters a live editor.
+	/// </summary>
+	/// <param name="editor">The editor to unregister.</param>
+	internal void UnregisterEditor(SharedVariableSetEditorProperty editor)
+	{
+		_editors.Remove(editor);
+	}
+
+	/// <summary>
+	/// Marks the set as changed and refreshes every live editor showing it.
+	/// </summary>
+	/// <param name="set">The set that changed.</param>
+	private void NotifyChanged(ForgeSharedVariableSet set)
+	{
+		set.EmitChanged();
+
+		foreach (SharedVariableSetEditorProperty editor in LiveEditorsFor(set))
+		{
+			editor.NotifyReplayedChangeInternal();
+		}
+	}
+
+	private List<SharedVariableSetEditorProperty> LiveEditorsFor(ForgeSharedVariableSet set)
+	{
+		var matches = new List<SharedVariableSetEditorProperty>();
+
+		for (int i = _editors.Count - 1; i >= 0; i--)
+		{
+			SharedVariableSetEditorProperty editor = _editors[i];
+
+			if (!IsInstanceValid(editor))
+			{
+				_editors.RemoveAt(i);
+				continue;
+			}
+
+			if (editor.EditsSetInternal(set))
+			{
+				matches.Add(editor);
+			}
+		}
+
+		return matches;
+	}
+}
+#endif

--- a/addons/forge/editor/statescript/SharedVariableSetEditingController.cs.uid
+++ b/addons/forge/editor/statescript/SharedVariableSetEditingController.cs.uid
@@ -1,0 +1,1 @@
+uid://k3apa3wmdh5s

--- a/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
+++ b/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
@@ -558,8 +558,6 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 		{
 			elementsContainer.Visible = x;
 
-			bool wasExpanded = !x;
-
 			if (x)
 			{
 				_expandedArrays.Add(def.VariableName);
@@ -569,15 +567,7 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 				_expandedArrays.Remove(def.VariableName);
 			}
 
-			EditorUndoRedoUtils.Record(
-				_undoRedo,
-				"Toggle Array Expand",
-				null,
-				undo =>
-				{
-					undo.AddDoMethod(this, MethodName.DoSetArrayExpanded, def.VariableName, x);
-					undo.AddUndoMethod(this, MethodName.DoSetArrayExpanded, def.VariableName, wasExpanded);
-				});
+			// Not recorded: expanding a row is view state, same as a collapsed foldable.
 		};
 
 		headerRow.AddChild(toggleButton);
@@ -1018,22 +1008,6 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 		}
 
 		NotifyChanged();
-		RebuildList();
-	}
-
-	private void DoSetArrayExpanded(string variableName, bool expanded)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		if (expanded)
-		{
-			_expandedArrays.Add(variableName);
-		}
-		else
-		{
-			_expandedArrays.Remove(variableName);
-		}
-
 		RebuildList();
 	}
 }

--- a/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
+++ b/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
@@ -2,6 +2,7 @@
 
 #if TOOLS
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Gamesmiths.Forge.Godot.Resources;
 using Gamesmiths.Forge.Godot.Resources.Statescript;
 using Godot;
@@ -27,7 +28,7 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 	private readonly HashSet<string> _expandedArrays = [];
 
-	private EditorUndoRedoManager? _undoRedo;
+	private SharedVariableSetEditingController? _controller;
 
 	private VBoxContainer? _root;
 	private VBoxContainer? _variableList;
@@ -44,17 +45,23 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 	private bool _signalsConnected;
 
 	/// <summary>
-	/// Sets the <see cref="EditorUndoRedoManager"/> used for undo/redo support.
+	/// Sets the controller that hosts this editor's undo/redo replays.
 	/// </summary>
-	/// <param name="undoRedo">The undo/redo manager from the editor plugin.</param>
-	public void SetUndoRedo(EditorUndoRedoManager? undoRedo)
+	/// <remarks>
+	/// The controller outlives this editor, which the inspector frees and rebuilds on every refresh. Recorded actions
+	/// target it rather than this instance so they still replay after a refresh.
+	/// </remarks>
+	/// <param name="controller">The shared editing controller from the editor plugin.</param>
+	public void SetEditingController(SharedVariableSetEditingController? controller)
 	{
-		_undoRedo = undoRedo;
+		_controller = controller;
 	}
 
 	public override void _Ready()
 	{
 		base._Ready();
+
+		_controller?.RegisterEditor(this);
 
 		_addIcon = EditorInterface.Singleton.GetEditorTheme().GetIcon("Add", "EditorIcons");
 		_removeIcon = EditorInterface.Singleton.GetEditorTheme().GetIcon("Remove", "EditorIcons");
@@ -134,6 +141,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 	public override void _ExitTree()
 	{
+		_controller?.UnregisterEditor(this);
+
 		DisconnectSignals();
 
 		if (GetEditedObject() is ForgeSharedVariableSet sharedVariableSet)
@@ -160,6 +169,43 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 		SyncSelectedVariableFromHighlightState();
 
 		RebuildList();
+	}
+
+	/// <summary>
+	/// Reports whether this editor is showing the given set, so a replay can refresh only the editors that matter.
+	/// </summary>
+	/// <param name="set">The set being replayed.</param>
+	/// <returns><see langword="true"/> when this editor edits that set.</returns>
+	internal bool EditsSetInternal(ForgeSharedVariableSet set)
+	{
+		return GetEditedObject() is ForgeSharedVariableSet edited && edited == set;
+	}
+
+	/// <summary>
+	/// Refreshes this editor after the controller replayed a change to the underlying set.
+	/// </summary>
+	internal void NotifyReplayedChangeInternal()
+	{
+		NotifyChanged();
+		RebuildList();
+	}
+
+	/// <summary>
+	/// Sets a variable's array row expanded state during a replay, so a restored element is not hidden in a collapsed
+	/// row. This is view state and is never recorded on its own.
+	/// </summary>
+	/// <param name="variableName">The variable whose row to expand or collapse.</param>
+	/// <param name="expanded">The expanded state to apply.</param>
+	internal void SetArrayExpandedInternal(string variableName, bool expanded)
+	{
+		if (expanded)
+		{
+			_expandedArrays.Add(variableName);
+		}
+		else
+		{
+			_expandedArrays.Remove(variableName);
+		}
 	}
 
 	private static void UpdateVariableNameButtonAppearance(Button button, bool isSelected)
@@ -682,55 +728,102 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 	private void SetVariableValue(ForgeSharedVariableDefinition def, Variant newValue)
 	{
+		if (!TryGetReplayContext(out SharedVariableSetEditingController? controller, out ForgeSharedVariableSet? set))
+		{
+			return;
+		}
+
 		Variant oldValue = def.InitialValue;
 
 		def.InitialValue = newValue;
 		NotifyChanged();
 
 		EditorUndoRedoUtils.Record(
-			_undoRedo,
+			controller.GetUndoRedo(),
 			$"Change Shared Variable '{def.VariableName}'",
-			null,
+			set,
 			undo =>
 			{
-				undo.AddDoMethod(this, MethodName.ApplyVariableValue, def, newValue);
-				undo.AddUndoMethod(this, MethodName.ApplyVariableValue, def, oldValue);
+				undo.AddDoMethod(
+					controller,
+					SharedVariableSetEditingController.MethodName.ReplayVariableValue,
+					set,
+					def,
+					newValue);
+				undo.AddUndoMethod(
+					controller,
+					SharedVariableSetEditingController.MethodName.ReplayVariableValue,
+					set,
+					def,
+					oldValue);
 			});
 	}
 
 	private void SetArrayElementValue(ForgeSharedVariableDefinition def, int index, Variant newValue)
 	{
+		if (!TryGetReplayContext(out SharedVariableSetEditingController? controller, out ForgeSharedVariableSet? set))
+		{
+			return;
+		}
+
 		Variant oldValue = def.InitialArrayValues[index];
 
 		def.InitialArrayValues[index] = newValue;
 		NotifyChanged();
 
 		EditorUndoRedoUtils.Record(
-			_undoRedo,
+			controller.GetUndoRedo(),
 			$"Change Shared Variable '{def.VariableName}' Element [{index}]",
-			null,
+			set,
 			undo =>
 			{
-				undo.AddDoMethod(this, MethodName.ApplyArrayElementValue, def, index, newValue);
-				undo.AddUndoMethod(this, MethodName.ApplyArrayElementValue, def, index, oldValue);
+				undo.AddDoMethod(
+					controller,
+					SharedVariableSetEditingController.MethodName.ReplayArrayElementValue,
+					set,
+					def,
+					index,
+					newValue);
+				undo.AddUndoMethod(
+					controller,
+					SharedVariableSetEditingController.MethodName.ReplayArrayElementValue,
+					set,
+					def,
+					index,
+					oldValue);
 			});
 	}
 
 	private void AddArrayElement(ForgeSharedVariableDefinition def, Variant value)
 	{
+		if (!TryGetReplayContext(out SharedVariableSetEditingController? controller, out ForgeSharedVariableSet? set))
+		{
+			return;
+		}
+
 		bool wasExpanded = _expandedArrays.Contains(def.VariableName);
 
 		EditorUndoRedoUtils.Record(
-			_undoRedo,
+			controller.GetUndoRedo(),
 			$"Add Element to '{def.VariableName}'",
-			null,
+			set,
 			undo =>
 			{
-				undo.AddDoMethod(this, MethodName.DoAddArrayElement, def, value);
-				undo.AddUndoMethod(this, MethodName.UndoAddArrayElement, def, wasExpanded);
+				undo.AddDoMethod(
+					controller,
+					SharedVariableSetEditingController.MethodName.ReplayAddArrayElement,
+					set,
+					def,
+					value);
+				undo.AddUndoMethod(
+					controller,
+					SharedVariableSetEditingController.MethodName.ReplayRemoveLastArrayElement,
+					set,
+					def,
+					wasExpanded);
 			},
 			execute: true,
-			fallback: () => DoAddArrayElement(def, value));
+			fallback: () => controller.ReplayAddArrayElement(set, def, value));
 	}
 
 	private void RemoveArrayElement(ForgeSharedVariableDefinition def, int index)
@@ -740,19 +833,35 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 			return;
 		}
 
+		if (!TryGetReplayContext(out SharedVariableSetEditingController? controller, out ForgeSharedVariableSet? set))
+		{
+			return;
+		}
+
 		Variant oldValue = def.InitialArrayValues[index];
 
 		EditorUndoRedoUtils.Record(
-			_undoRedo,
+			controller.GetUndoRedo(),
 			$"Remove Element [{index}] from '{def.VariableName}'",
-			null,
+			set,
 			undo =>
 			{
-				undo.AddDoMethod(this, MethodName.DoRemoveArrayElement, def, index);
-				undo.AddUndoMethod(this, MethodName.UndoRemoveArrayElement, def, index, oldValue);
+				undo.AddDoMethod(
+					controller,
+					SharedVariableSetEditingController.MethodName.ReplayRemoveArrayElementAt,
+					set,
+					def,
+					index);
+				undo.AddUndoMethod(
+					controller,
+					SharedVariableSetEditingController.MethodName.ReplayInsertArrayElement,
+					set,
+					def,
+					index,
+					oldValue);
 			},
 			execute: true,
-			fallback: () => DoRemoveArrayElement(def, index));
+			fallback: () => controller.ReplayRemoveArrayElementAt(set, def, index));
 	}
 
 	private void OnAddPressed()
@@ -832,19 +941,31 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 				: StatescriptVariableTypeConverter.CreateDefaultGodotVariant(selection.PrimitiveType),
 		};
 
-		Array<ForgeSharedVariableDefinition> definitions = GetDefinitions();
+		if (!TryGetReplayContext(out SharedVariableSetEditingController? controller, out ForgeSharedVariableSet? set))
+		{
+			CleanupCreationDialog();
+			return;
+		}
 
 		EditorUndoRedoUtils.Record(
-			_undoRedo,
+			controller.GetUndoRedo(),
 			"Add Shared Variable",
-			null,
+			set,
 			undo =>
 			{
-				undo.AddDoMethod(this, MethodName.DoAddVariable, definitions, newDef);
-				undo.AddUndoMethod(this, MethodName.UndoAddVariable, definitions, newDef);
+				undo.AddDoMethod(
+					controller,
+					SharedVariableSetEditingController.MethodName.ReplayAddVariable,
+					set,
+					newDef);
+				undo.AddUndoMethod(
+					controller,
+					SharedVariableSetEditingController.MethodName.ReplayRemoveVariable,
+					set,
+					newDef);
 			},
 			execute: true,
-			fallback: () => DoAddVariable(definitions, newDef));
+			fallback: () => controller.ReplayAddVariable(set, newDef));
 
 		CleanupCreationDialog();
 	}
@@ -874,141 +995,47 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 		ForgeSharedVariableDefinition variable = definitions[index];
 
+		if (!TryGetReplayContext(out SharedVariableSetEditingController? controller, out ForgeSharedVariableSet? set))
+		{
+			return;
+		}
+
 		EditorUndoRedoUtils.Record(
-			_undoRedo,
+			controller.GetUndoRedo(),
 			"Remove Shared Variable",
-			null,
+			set,
 			undo =>
 			{
-				undo.AddDoMethod(this, MethodName.DoRemoveVariable, definitions, variable, index);
-				undo.AddUndoMethod(this, MethodName.UndoRemoveVariable, definitions, variable, index);
+				undo.AddDoMethod(
+					controller,
+					SharedVariableSetEditingController.MethodName.ReplayRemoveVariable,
+					set,
+					variable);
+				undo.AddUndoMethod(
+					controller,
+					SharedVariableSetEditingController.MethodName.ReplayInsertVariable,
+					set,
+					variable,
+					index);
 			},
 			execute: true,
-			fallback: () => DoRemoveVariable(definitions, index));
+			fallback: () => controller.ReplayRemoveVariable(set, variable));
 	}
 
-	private void ApplyVariableValue(ForgeSharedVariableDefinition def, Variant value)
+	/// <summary>
+	/// Resolves the controller that hosts undo/redo replays and the set being edited.
+	/// </summary>
+	/// <param name="controller">The editing controller, when available.</param>
+	/// <param name="set">The set being edited, when available.</param>
+	/// <returns><see langword="true"/> when both are available.</returns>
+	private bool TryGetReplayContext(
+		[NotNullWhen(true)] out SharedVariableSetEditingController? controller,
+		[NotNullWhen(true)] out ForgeSharedVariableSet? set)
 	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+		controller = _controller;
+		set = GetEditedObject() as ForgeSharedVariableSet;
 
-		def.InitialValue = value;
-		NotifyChanged();
-		RebuildList();
-	}
-
-	private void ApplyArrayElementValue(ForgeSharedVariableDefinition def, int index, Variant value)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		def.InitialArrayValues[index] = value;
-		NotifyChanged();
-		RebuildList();
-	}
-
-	private void DoAddVariable(Array<ForgeSharedVariableDefinition> definitions, ForgeSharedVariableDefinition def)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		definitions.Add(def);
-		NotifyChanged();
-		RebuildList();
-	}
-
-	private void UndoAddVariable(Array<ForgeSharedVariableDefinition> definitions, ForgeSharedVariableDefinition def)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		definitions.Remove(def);
-		NotifyChanged();
-		RebuildList();
-	}
-
-	private void DoRemoveVariable(
-		Array<ForgeSharedVariableDefinition> definitions,
-		int index)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		definitions.RemoveAt(index);
-		NotifyChanged();
-		RebuildList();
-	}
-
-	private void UndoRemoveVariable(
-		Array<ForgeSharedVariableDefinition> definitions,
-		ForgeSharedVariableDefinition sharedVariableDefinition,
-		int index)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		if (index >= definitions.Count)
-		{
-			definitions.Add(sharedVariableDefinition);
-		}
-		else
-		{
-			definitions.Insert(index, sharedVariableDefinition);
-		}
-
-		NotifyChanged();
-		RebuildList();
-	}
-
-	private void DoAddArrayElement(ForgeSharedVariableDefinition sharedVariableDefinition, Variant value)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		sharedVariableDefinition.InitialArrayValues.Add(value);
-		_expandedArrays.Add(sharedVariableDefinition.VariableName);
-		NotifyChanged();
-		RebuildList();
-	}
-
-	private void UndoAddArrayElement(ForgeSharedVariableDefinition sharedVariableDefinition, bool wasExpanded)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		if (sharedVariableDefinition.InitialArrayValues.Count > 0)
-		{
-			sharedVariableDefinition.InitialArrayValues.RemoveAt(sharedVariableDefinition.InitialArrayValues.Count - 1);
-		}
-
-		if (!wasExpanded)
-		{
-			_expandedArrays.Remove(sharedVariableDefinition.VariableName);
-		}
-
-		NotifyChanged();
-		RebuildList();
-	}
-
-	private void DoRemoveArrayElement(ForgeSharedVariableDefinition sharedVariableDefinition, int index)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		sharedVariableDefinition.InitialArrayValues.RemoveAt(index);
-		NotifyChanged();
-		RebuildList();
-	}
-
-	private void UndoRemoveArrayElement(
-		ForgeSharedVariableDefinition sharedVariableDefinition,
-		int index,
-		Variant value)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		if (index >= sharedVariableDefinition.InitialArrayValues.Count)
-		{
-			sharedVariableDefinition.InitialArrayValues.Add(value);
-		}
-		else
-		{
-			sharedVariableDefinition.InitialArrayValues.Insert(index, value);
-		}
-
-		NotifyChanged();
-		RebuildList();
+		return controller is not null && IsInstanceValid(controller) && set is not null;
 	}
 }
 #endif

--- a/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
+++ b/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
@@ -899,6 +899,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 	private void ApplyVariableValue(ForgeSharedVariableDefinition def, Variant value)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		def.InitialValue = value;
 		NotifyChanged();
 		RebuildList();
@@ -906,6 +908,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 	private void ApplyArrayElementValue(ForgeSharedVariableDefinition def, int index, Variant value)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		def.InitialArrayValues[index] = value;
 		NotifyChanged();
 		RebuildList();
@@ -913,6 +917,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 	private void DoAddVariable(Array<ForgeSharedVariableDefinition> definitions, ForgeSharedVariableDefinition def)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		definitions.Add(def);
 		NotifyChanged();
 		RebuildList();
@@ -920,6 +926,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 	private void UndoAddVariable(Array<ForgeSharedVariableDefinition> definitions, ForgeSharedVariableDefinition def)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		definitions.Remove(def);
 		NotifyChanged();
 		RebuildList();
@@ -929,6 +937,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 		Array<ForgeSharedVariableDefinition> definitions,
 		int index)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		definitions.RemoveAt(index);
 		NotifyChanged();
 		RebuildList();
@@ -939,6 +949,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 		ForgeSharedVariableDefinition sharedVariableDefinition,
 		int index)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (index >= definitions.Count)
 		{
 			definitions.Add(sharedVariableDefinition);
@@ -954,6 +966,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 	private void DoAddArrayElement(ForgeSharedVariableDefinition sharedVariableDefinition, Variant value)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		sharedVariableDefinition.InitialArrayValues.Add(value);
 		_expandedArrays.Add(sharedVariableDefinition.VariableName);
 		NotifyChanged();
@@ -962,6 +976,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 	private void UndoAddArrayElement(ForgeSharedVariableDefinition sharedVariableDefinition, bool wasExpanded)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (sharedVariableDefinition.InitialArrayValues.Count > 0)
 		{
 			sharedVariableDefinition.InitialArrayValues.RemoveAt(sharedVariableDefinition.InitialArrayValues.Count - 1);
@@ -978,6 +994,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 	private void DoRemoveArrayElement(ForgeSharedVariableDefinition sharedVariableDefinition, int index)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		sharedVariableDefinition.InitialArrayValues.RemoveAt(index);
 		NotifyChanged();
 		RebuildList();
@@ -988,6 +1006,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 		int index,
 		Variant value)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (index >= sharedVariableDefinition.InitialArrayValues.Count)
 		{
 			sharedVariableDefinition.InitialArrayValues.Add(value);
@@ -1003,6 +1023,8 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 
 	private void DoSetArrayExpanded(string variableName, bool expanded)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (expanded)
 		{
 			_expandedArrays.Add(variableName);

--- a/addons/forge/editor/statescript/SharedVariableSetInspectorPlugin.cs
+++ b/addons/forge/editor/statescript/SharedVariableSetInspectorPlugin.cs
@@ -12,15 +12,15 @@ namespace Gamesmiths.Forge.Godot.Editor.Statescript;
 /// </summary>
 public partial class SharedVariableSetInspectorPlugin : EditorInspectorPlugin
 {
-	private EditorUndoRedoManager? _undoRedo;
+	private SharedVariableSetEditingController? _controller;
 
 	/// <summary>
-	/// Sets the <see cref="EditorUndoRedoManager"/> used for undo/redo support.
+	/// Sets the controller that hosts undo/redo replays for the editors this plugin creates.
 	/// </summary>
-	/// <param name="undoRedo">The undo/redo manager from the editor plugin.</param>
-	public void SetUndoRedo(EditorUndoRedoManager undoRedo)
+	/// <param name="controller">The shared editing controller from the editor plugin.</param>
+	public void SetEditingController(SharedVariableSetEditingController controller)
 	{
-		_undoRedo = undoRedo;
+		_controller = controller;
 	}
 
 	/// <inheritdoc/>
@@ -45,7 +45,7 @@ public partial class SharedVariableSetInspectorPlugin : EditorInspectorPlugin
 		}
 
 		var editorProperty = new SharedVariableSetEditorProperty();
-		editorProperty.SetUndoRedo(_undoRedo);
+		editorProperty.SetEditingController(_controller);
 		AddPropertyEditor(name, editorProperty);
 		return true;
 	}

--- a/addons/forge/editor/statescript/StatescriptGraphEditorDock.GraphOperations.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphEditorDock.GraphOperations.cs
@@ -131,126 +131,132 @@ public partial class StatescriptGraphEditorDock
 			return;
 		}
 
+		var nodesToDelete = new GodotCollections.Array<StatescriptNode>();
+		var deletedIds = new HashSet<string>();
+
 		foreach (StringName nodeName in deletedNodes)
 		{
-			Node? child = _graphEdit.GetNodeOrNull(nodeName.ToString());
-
-			if (child is not StatescriptGraphNode graphNode)
+			if (_graphEdit.GetNodeOrNull(nodeName.ToString()) is not StatescriptGraphNode graphNode
+				|| graphNode.NodeResource is null)
 			{
 				continue;
 			}
 
-			if (graphNode.NodeResource?.NodeType == StatescriptNodeType.Entry)
+			if (graphNode.NodeResource.NodeType == StatescriptNodeType.Entry)
 			{
 				GD.PushWarning("Cannot delete the Entry statescriptNode.");
 				continue;
 			}
 
-			if (graphNode.NodeResource is null)
-			{
-				continue;
-			}
-
-			var affectedConnections = new List<StatescriptConnection>();
-			foreach (GodotCollections.Dictionary connection in _graphEdit.GetConnectionList())
-			{
-				StringName from = connection["from_node"].AsStringName();
-				StringName to = connection["to_node"].AsStringName();
-
-				if (from == nodeName || to == nodeName)
-				{
-					affectedConnections.Add(new StatescriptConnection
-					{
-						FromNode = connection["from_node"].AsString(),
-						OutputPort = ToRuntimeOutputPort(
-							connection["from_node"].AsString(),
-							connection["from_port"].AsInt32()),
-						ToNode = connection["to_node"].AsString(),
-						InputPort = connection["to_port"].AsInt32(),
-					});
-				}
-			}
-
-			StatescriptNode nodeResource = graphNode.NodeResource;
-			EditorUndoRedoUtils.Record(
-				_undoRedo,
-				"Delete Statescript Node",
-				graph,
-				undo =>
-				{
-					undo.AddDoMethod(
-						this,
-						MethodName.DoDeleteNode,
-						graph,
-						nodeResource,
-						new GodotCollections.Array<StatescriptConnection>(affectedConnections));
-					undo.AddUndoMethod(
-						this,
-						MethodName.UndoDeleteNode,
-						graph,
-						nodeResource,
-						new GodotCollections.Array<StatescriptConnection>(affectedConnections));
-				},
-				execute: true,
-				fallback: () => DoDeleteNode(graph, nodeResource, [.. affectedConnections]));
+			nodesToDelete.Add(graphNode.NodeResource);
+			deletedIds.Add(graphNode.NodeResource.NodeId);
 		}
+
+		if (nodesToDelete.Count == 0)
+		{
+			return;
+		}
+
+		// Off the resource rather than the visual connection list: keeps the instances that have to be removed and
+		// restored, and captures a connection between two deleted nodes once instead of once per endpoint.
+		var affectedConnections = new GodotCollections.Array<StatescriptConnection>();
+		foreach (StatescriptConnection connection in graph.Connections)
+		{
+			if (deletedIds.Contains(connection.FromNode) || deletedIds.Contains(connection.ToNode))
+			{
+				affectedConnections.Add(connection);
+			}
+		}
+
+		EditorUndoRedoUtils.Record(
+			_undoRedo,
+			nodesToDelete.Count > 1 ? "Delete Statescript Nodes" : "Delete Statescript Node",
+			graph,
+			undo =>
+			{
+				undo.AddDoMethod(this, MethodName.DoDeleteNodes, graph, nodesToDelete, affectedConnections);
+				undo.AddUndoMethod(this, MethodName.UndoDeleteNodes, graph, nodesToDelete, affectedConnections);
+			},
+			execute: true,
+			fallback: () => DoDeleteNodes(graph, nodesToDelete, affectedConnections));
 	}
 
-	private void DoDeleteNode(
+	private void DoDeleteNodes(
 		StatescriptGraph graph,
-		StatescriptNode nodeResource,
+		GodotCollections.Array<StatescriptNode> nodes,
 		GodotCollections.Array<StatescriptConnection> affectedConnections)
 	{
 		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
 
-		if (_graphEdit is not null && CurrentGraph == graph)
+		bool isCurrent = _graphEdit is not null && CurrentGraph == graph;
+
+		if (isCurrent)
 		{
+			// Must precede node removal: the runtime-to-visual port mapping is read off the live node.
 			foreach (StatescriptConnection connection in affectedConnections)
 			{
-				_graphEdit.DisconnectNode(
+				_graphEdit!.DisconnectNode(
 					connection.FromNode,
 					ToVisualOutputPort(connection.FromNode, connection.OutputPort),
 					connection.ToNode,
 					connection.InputPort);
 			}
-
-			Node? child = _graphEdit.GetNodeOrNull(nodeResource.NodeId);
-			if (child is StatescriptGraphNode graphNode)
-			{
-				ReleaseGraphNodeVisualDeferred(graphNode);
-			}
-			else
-			{
-				child?.QueueFree();
-			}
 		}
-		else
+
+		// Explicit, because SyncConnectionsToCurrentGraph only syncs the visible graph: deleting in a background tab
+		// used to leave these behind for good.
+		foreach (StatescriptConnection connection in affectedConnections)
+		{
+			graph.Connections.Remove(connection);
+		}
+
+		foreach (StatescriptNode nodeResource in nodes)
+		{
+			if (isCurrent)
+			{
+				Node? child = _graphEdit!.GetNodeOrNull(nodeResource.NodeId);
+				if (child is StatescriptGraphNode graphNode)
+				{
+					ReleaseGraphNodeVisualDeferred(graphNode);
+				}
+				else
+				{
+					child?.QueueFree();
+				}
+			}
+
+			graph.Nodes.Remove(nodeResource);
+		}
+
+		if (!isCurrent)
 		{
 			InvalidateCachedGraphVisuals(graph);
 		}
 
-		graph.Nodes.Remove(nodeResource);
 		graph.EmitChanged();
-		SyncConnectionsToCurrentGraph();
 	}
 
-	private void UndoDeleteNode(
+	private void UndoDeleteNodes(
 		StatescriptGraph graph,
-		StatescriptNode nodeResource,
+		GodotCollections.Array<StatescriptNode> nodes,
 		GodotCollections.Array<StatescriptConnection> affectedConnections)
 	{
 		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
 
-		graph.Nodes.Add(nodeResource);
-
+		// Every node goes back before any connection does, since a restored connection may span two of them.
+		graph.Nodes.AddRange(nodes);
 		graph.Connections.AddRange(affectedConnections);
 		graph.EmitChanged();
 
 		if (CurrentGraph == graph && _graphEdit is not null)
 		{
 			GraphTab? tab = FindTab(graph);
-			StatescriptGraphNode graphNode = AddGraphNodeVisual(nodeResource, graph);
-			tab?.CachedGraphNodes.Add(graphNode);
+
+			foreach (StatescriptNode nodeResource in nodes)
+			{
+				StatescriptGraphNode graphNode = AddGraphNodeVisual(nodeResource, graph);
+				tab?.CachedGraphNodes.Add(graphNode);
+			}
 
 			foreach (StatescriptConnection connection in affectedConnections)
 			{

--- a/addons/forge/editor/statescript/StatescriptGraphEditorDock.GraphOperations.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphEditorDock.GraphOperations.cs
@@ -79,12 +79,16 @@ public partial class StatescriptGraphEditorDock
 
 	private void DoConnect(string fromNode, int fromPort, string toNode, int toPort)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		_graphEdit?.ConnectNode(fromNode, ToVisualOutputPort(fromNode, fromPort), toNode, toPort);
 		SyncConnectionsToCurrentGraph();
 	}
 
 	private void UndoConnect(string fromNode, int fromPort, string toNode, int toPort)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		_graphEdit?.DisconnectNode(fromNode, ToVisualOutputPort(fromNode, fromPort), toNode, toPort);
 		SyncConnectionsToCurrentGraph();
 	}
@@ -197,6 +201,8 @@ public partial class StatescriptGraphEditorDock
 		StatescriptNode nodeResource,
 		GodotCollections.Array<StatescriptConnection> affectedConnections)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (_graphEdit is not null && CurrentGraph == graph)
 		{
 			foreach (StatescriptConnection connection in affectedConnections)
@@ -233,6 +239,8 @@ public partial class StatescriptGraphEditorDock
 		StatescriptNode nodeResource,
 		GodotCollections.Array<StatescriptConnection> affectedConnections)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		graph.Nodes.Add(nodeResource);
 
 		graph.Connections.AddRange(affectedConnections);
@@ -328,6 +336,8 @@ public partial class StatescriptGraphEditorDock
 		StatescriptGraph graph,
 		GodotCollections.Dictionary<StringName, Vector2> positions)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		foreach (StatescriptNode node in graph.Nodes)
 		{
 			if (positions.TryGetValue(node.NodeId, out Vector2 pos))
@@ -388,6 +398,8 @@ public partial class StatescriptGraphEditorDock
 
 	private void DoAddNode(StatescriptGraph graph, StatescriptNode nodeResource)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		graph.Nodes.Add(nodeResource);
 		graph.EmitChanged();
 
@@ -401,6 +413,8 @@ public partial class StatescriptGraphEditorDock
 
 	private void UndoAddNode(StatescriptGraph graph, StatescriptNode nodeResource)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		graph.Nodes.Remove(nodeResource);
 		graph.EmitChanged();
 
@@ -552,6 +566,8 @@ public partial class StatescriptGraphEditorDock
 		GodotCollections.Array<StatescriptNode> nodes,
 		GodotCollections.Array<StatescriptConnection> connections)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		graph.Nodes.AddRange(nodes);
 
 		graph.Connections.AddRange(connections);
@@ -590,6 +606,8 @@ public partial class StatescriptGraphEditorDock
 		GodotCollections.Array<StatescriptNode> nodes,
 		GodotCollections.Array<StatescriptConnection> connections)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		foreach (StatescriptConnection connection in connections)
 		{
 			graph.Connections.Remove(connection);

--- a/addons/forge/editor/statescript/StatescriptGraphEditorDock.NodeReplay.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphEditorDock.NodeReplay.cs
@@ -1,0 +1,288 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Gamesmiths.Forge.Godot.Resources.Statescript;
+using Godot;
+using GodotCollections = Godot.Collections;
+
+namespace Gamesmiths.Forge.Godot.Editor.Statescript;
+
+/// <summary>
+/// Undo/redo replay callbacks for per-node edits (config, width, resolver bindings, layout).
+/// </summary>
+/// <remarks>
+/// <para>
+/// These live on the dock rather than on the <see cref="StatescriptGraphNode"/> visual, which is freed when the node
+/// is deleted, its tab closes, or cached visuals are invalidated. Godot's <c>UndoRedo</c> silently skips operations
+/// whose target object is gone, so per-node actions registered on the visual stopped replaying once undo removed the
+/// node: redo appeared to die past that point.
+/// </para>
+/// <para>
+/// Each callback resolves the node by <c>(graph, nodeId)</c> at replay time, going through the live visual when the
+/// graph is on screen so the UI rebuilds in the same step, and through the resource otherwise.
+/// </para>
+/// </remarks>
+public partial class StatescriptGraphEditorDock
+{
+	private static StatescriptNode? FindNodeResource(StatescriptGraph graph, string nodeId)
+	{
+		foreach (StatescriptNode node in graph.Nodes)
+		{
+			if (node.NodeId == nodeId)
+			{
+				return node;
+			}
+		}
+
+		return null;
+	}
+
+	private static void WriteCustomDataToResource(StatescriptNode node, GodotCollections.Dictionary customData)
+	{
+		foreach (KeyValuePair<Variant, Variant> entry in customData)
+		{
+			string key = entry.Key.AsString();
+
+			if (entry.Value.VariantType == Variant.Type.Nil)
+			{
+				node.CustomData.Remove(key);
+				continue;
+			}
+
+			node.CustomData[key] = entry.Value;
+		}
+	}
+
+	private static void SetBindingOnResource(
+		StatescriptNode node,
+		StatescriptPropertyDirection direction,
+		int propertyIndex,
+		Variant resolverVariant)
+	{
+		if (resolverVariant.AsGodotObject() is not StatescriptResolverResource resolver)
+		{
+			for (int i = node.PropertyBindings.Count - 1; i >= 0; i--)
+			{
+				StatescriptNodeProperty binding = node.PropertyBindings[i];
+
+				if (binding.Direction == direction && binding.PropertyIndex == propertyIndex)
+				{
+					node.PropertyBindings.RemoveAt(i);
+				}
+			}
+
+			return;
+		}
+
+		foreach (StatescriptNodeProperty binding in node.PropertyBindings)
+		{
+			if (binding.Direction == direction && binding.PropertyIndex == propertyIndex)
+			{
+				binding.Resolver = resolver;
+				return;
+			}
+		}
+
+		node.PropertyBindings.Add(new StatescriptNodeProperty
+		{
+			Direction = direction,
+			PropertyIndex = propertyIndex,
+			Resolver = resolver,
+		});
+	}
+
+	/// <summary>
+	/// Mirrors the live visual's <c>EnsurePropertyVisible</c> on the resource, so a restored value is not hidden in a
+	/// collapsed section when the tab is next shown.
+	/// </summary>
+	/// <param name="node">The node resource to write fold state to.</param>
+	/// <param name="direction">The direction of the property (input or output).</param>
+	/// <param name="propertyIndex">The index of the property.</param>
+	private static void EnsurePropertyVisibleOnResource(
+		StatescriptNode node,
+		StatescriptPropertyDirection direction,
+		int propertyIndex)
+	{
+		if (direction == StatescriptPropertyDirection.Input)
+		{
+			node.CustomData[StatescriptGraphNode.FoldInputKey] = false;
+			node.CustomData[$"{StatescriptGraphNode.FoldInputPropertyKeyPrefix}{propertyIndex}"] = false;
+		}
+		else
+		{
+			node.CustomData[StatescriptGraphNode.FoldOutputKey] = false;
+		}
+	}
+
+	private void ReplayNodeConfig(StatescriptGraph graph, string nodeId, string key, Variant value)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		if (TryGetLiveNodeVisual(graph, nodeId, out StatescriptGraphNode? visual))
+		{
+			visual.ApplyNodeConfigInternal(key, value);
+			return;
+		}
+
+		StatescriptNode? node = FindNodeResource(graph, nodeId);
+		if (node is null)
+		{
+			return;
+		}
+
+		if (value.VariantType == Variant.Type.Nil)
+		{
+			node.CustomData.Remove(key);
+		}
+		else
+		{
+			node.CustomData[key] = value;
+		}
+
+		MarkReplayedNodeChanged(graph, node);
+	}
+
+	private void ReplayNodeWidth(StatescriptGraph graph, string nodeId, float width)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		if (TryGetLiveNodeVisual(graph, nodeId, out StatescriptGraphNode? visual))
+		{
+			visual.ApplyCustomWidthInternal(width);
+			return;
+		}
+
+		StatescriptNode? node = FindNodeResource(graph, nodeId);
+		if (node is null)
+		{
+			return;
+		}
+
+		node.CustomData[StatescriptGraphNode.CustomWidthKey] = Variant.From(width);
+		MarkReplayedNodeChanged(graph, node);
+	}
+
+	private void ReplayResolverBinding(
+		StatescriptGraph graph,
+		string nodeId,
+		int directionInt,
+		int propertyIndex,
+		Variant resolverVariant)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		if (TryGetLiveNodeVisual(graph, nodeId, out StatescriptGraphNode? visual))
+		{
+			visual.ApplyResolverBindingInternal(directionInt, propertyIndex, resolverVariant);
+			return;
+		}
+
+		StatescriptNode? node = FindNodeResource(graph, nodeId);
+		if (node is null)
+		{
+			return;
+		}
+
+		var direction = (StatescriptPropertyDirection)directionInt;
+		SetBindingOnResource(node, direction, propertyIndex, resolverVariant);
+		EnsurePropertyVisibleOnResource(node, direction, propertyIndex);
+		MarkReplayedNodeChanged(graph, node);
+	}
+
+	private void ReplayInputPropertyConfig(
+		StatescriptGraph graph,
+		string nodeId,
+		GodotCollections.Dictionary customData,
+		int propertyIndex,
+		Variant resolverVariant)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		if (TryGetLiveNodeVisual(graph, nodeId, out StatescriptGraphNode? visual))
+		{
+			visual.ApplyInputPropertyConfigInternal(customData, propertyIndex, resolverVariant);
+			return;
+		}
+
+		StatescriptNode? node = FindNodeResource(graph, nodeId);
+		if (node is null)
+		{
+			return;
+		}
+
+		WriteCustomDataToResource(node, customData);
+		SetBindingOnResource(node, StatescriptPropertyDirection.Input, propertyIndex, resolverVariant);
+		EnsurePropertyVisibleOnResource(node, StatescriptPropertyDirection.Input, propertyIndex);
+		MarkReplayedNodeChanged(graph, node);
+	}
+
+	private void ReplayLayoutConfig(
+		StatescriptGraph graph,
+		string nodeId,
+		GodotCollections.Dictionary customData,
+		GodotCollections.Array<StatescriptConnection> connectionsToRemove,
+		GodotCollections.Array<StatescriptConnection> connectionsToAdd)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		if (TryGetLiveNodeVisual(graph, nodeId, out StatescriptGraphNode? visual))
+		{
+			visual.ApplyLayoutConfigInternal(customData, connectionsToRemove, connectionsToAdd);
+			return;
+		}
+
+		StatescriptNode? node = FindNodeResource(graph, nodeId);
+		if (node is null)
+		{
+			return;
+		}
+
+		foreach (StatescriptConnection connection in connectionsToRemove)
+		{
+			graph.Connections.Remove(connection);
+		}
+
+		WriteCustomDataToResource(node, customData);
+
+		foreach (StatescriptConnection connection in connectionsToAdd)
+		{
+			if (!graph.Connections.Contains(connection))
+			{
+				graph.Connections.Add(connection);
+			}
+		}
+
+		MarkReplayedNodeChanged(graph, node);
+	}
+
+	/// <summary>
+	/// Resolves the live visual for a node when its graph is the one on screen.
+	/// </summary>
+	/// <param name="graph">The graph the recorded action belongs to.</param>
+	/// <param name="nodeId">The node's id, which is also the visual's name in the graph edit.</param>
+	/// <param name="visual">The live visual, when there is one.</param>
+	/// <returns><see langword="true"/> when the node's visual is currently alive and shown.</returns>
+	private bool TryGetLiveNodeVisual(
+		StatescriptGraph graph,
+		string nodeId,
+		[NotNullWhen(true)] out StatescriptGraphNode? visual)
+	{
+		visual = CurrentGraph == graph
+			&& _graphEdit?.GetNodeOrNull(nodeId) is StatescriptGraphNode candidate
+			&& candidate.NodeResource is not null
+			? candidate
+			: null;
+
+		return visual is not null;
+	}
+
+	private void MarkReplayedNodeChanged(StatescriptGraph graph, StatescriptNode node)
+	{
+		node.EmitChanged();
+		graph.EmitChanged();
+		InvalidateCachedGraphVisuals(graph);
+	}
+}
+#endif

--- a/addons/forge/editor/statescript/StatescriptGraphEditorDock.NodeReplay.cs.uid
+++ b/addons/forge/editor/statescript/StatescriptGraphEditorDock.NodeReplay.cs.uid
@@ -1,0 +1,1 @@
+uid://ca3kkqmtdfyv0

--- a/addons/forge/editor/statescript/StatescriptGraphEditorDock.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphEditorDock.cs
@@ -1082,6 +1082,7 @@ public partial class StatescriptGraphEditorDock : EditorDock, ISerializationList
 		_graphEdit!.AddChild(graphNode);
 		graphNode.Initialize(nodeResource, graph);
 		graphNode.SetUndoRedo(_undoRedo);
+		graphNode.SetReplayHost(this);
 		graphNode.PropertyBindingChanged += OnGraphNodePropertyBindingChanged;
 		return graphNode;
 	}

--- a/addons/forge/editor/statescript/StatescriptGraphNode.PropertyEditors.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.PropertyEditors.cs
@@ -278,25 +278,12 @@ public partial class StatescriptGraphNode
 		StatescriptNodeProperty? updated = FindBinding(StatescriptPropertyDirection.Input, index);
 		var newResolver = updated?.Resolver?.Duplicate() as StatescriptResolverResource;
 
-		EditorUndoRedoUtils.Record(
-			_undoRedo,
-			"Change Resolver Type",
-			_graph,
-			undo =>
-			{
-				undo.AddDoMethod(
-					this,
-					MethodName.ApplyResolverBinding,
-					(int)StatescriptPropertyDirection.Input,
-					index,
-					Variant.From(newResolver));
-				undo.AddUndoMethod(
-					this,
-					MethodName.ApplyResolverBinding,
-					(int)StatescriptPropertyDirection.Input,
-					index,
-					Variant.From(oldResolver));
-			});
+		RecordResolverBindingChangeInternal(
+			StatescriptPropertyDirection.Input,
+			index,
+			oldResolver,
+			newResolver,
+			"Change Resolver Type");
 
 		PropertyBindingChanged?.Invoke();
 		ResetSize();
@@ -415,25 +402,12 @@ public partial class StatescriptGraphNode
 		EnsureBinding(StatescriptPropertyDirection.Output, index).Resolver = newResolver;
 		NotifyGraphResourceChanged();
 
-		EditorUndoRedoUtils.Record(
-			_undoRedo,
-			"Change Output Variable",
-			_graph,
-			undo =>
-			{
-				undo.AddDoMethod(
-					this,
-					MethodName.ApplyResolverBinding,
-					(int)StatescriptPropertyDirection.Output,
-					index,
-					(StatescriptResolverResource)newResolver.Duplicate());
-				undo.AddUndoMethod(
-					this,
-					MethodName.ApplyResolverBinding,
-					(int)StatescriptPropertyDirection.Output,
-					index,
-					Variant.From(oldResolver));
-			});
+		RecordResolverBindingChangeInternal(
+			StatescriptPropertyDirection.Output,
+			index,
+			oldResolver,
+			(StatescriptResolverResource)newResolver.Duplicate(),
+			"Change Output Variable");
 
 		PropertyBindingChanged?.Invoke();
 	}
@@ -489,25 +463,7 @@ public partial class StatescriptGraphNode
 		StatescriptNodeProperty? updated = FindBinding(direction, propertyIndex);
 		var newResolver = updated?.Resolver?.Duplicate() as StatescriptResolverResource;
 
-		EditorUndoRedoUtils.Record(
-			_undoRedo,
-			"Change Node Property",
-			_graph,
-			undo =>
-			{
-				undo.AddDoMethod(
-					this,
-					MethodName.ApplyResolverBinding,
-					(int)direction,
-					propertyIndex,
-					Variant.From(newResolver));
-				undo.AddUndoMethod(
-					this,
-					MethodName.ApplyResolverBinding,
-					(int)direction,
-					propertyIndex,
-					Variant.From(oldResolver));
-			});
+		RecordResolverBindingChangeInternal(direction, propertyIndex, oldResolver, newResolver, "Change Node Property");
 
 		if (direction == StatescriptPropertyDirection.Input)
 		{

--- a/addons/forge/editor/statescript/StatescriptGraphNode.PropertyEditors.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.PropertyEditors.cs
@@ -121,7 +121,10 @@ public partial class StatescriptGraphNode
 		// Pre-seed a constant binding for inputs whose conventional default is not the type's zero value (e.g.
 		// Level = 1), so a fresh slot starts from it and the dropdown selects the constant resolver. Optional inputs
 		// are never seeded: their fresh state is (None), which is what the runtime documents as their default.
+		// Never during a replay: an undo that cleared this slot rebuilds the row, and seeding would put the binding
+		// straight back, making the undo look like it did nothing.
 		if (binding?.Resolver is null
+			&& !EditorUndoRedoUtils.IsReplaying
 			&& !propInfo.IsOptional
 			&& defaultConstantValue is { } seededValue
 			&& StatescriptVariableTypeConverter.TryFromSystemType(
@@ -204,6 +207,7 @@ public partial class StatescriptGraphNode
 			// Persist the default resolver binding for a fresh input slot so the value shown in the editor is the value
 			// used at runtime, without requiring the user to interact with the slot first.
 			if (binding?.Resolver is null
+				&& !EditorUndoRedoUtils.IsReplaying
 				&& _activeResolverEditors.TryGetValue(key, out NodeEditorProperty? defaultEditor))
 			{
 				defaultEditor.SaveTo(EnsureBinding(StatescriptPropertyDirection.Input, index));
@@ -343,7 +347,8 @@ public partial class StatescriptGraphNode
 		{
 			variableDropdown.Selected = selectedIndex;
 
-			if (binding is null)
+			// Auto-bind a fresh output row to the shown variable so the dropdown is not lying about what runs.
+			if (binding is null && !EditorUndoRedoUtils.IsReplaying)
 			{
 				StatescriptGraphVariable variable = _graph.Variables[selectedIndex];
 				EnsureBinding(StatescriptPropertyDirection.Output, index).Resolver =

--- a/addons/forge/editor/statescript/StatescriptGraphNode.PropertyEditors.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.PropertyEditors.cs
@@ -388,7 +388,7 @@ public partial class StatescriptGraphNode
 
 		foldable.FoldingChanged += folded =>
 		{
-			SetFoldStateWithUndo(foldKey, folded);
+			PersistFoldState(foldKey, folded);
 			UpdateOutputVariableBadge();
 			ResetSize();
 		};

--- a/addons/forge/editor/statescript/StatescriptGraphNode.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.cs
@@ -18,10 +18,11 @@ namespace Gamesmiths.Forge.Godot.Editor.Statescript;
 [Tool]
 public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 {
-	private const string FoldInputKey = "_fold_input";
-	private const string FoldOutputKey = "_fold_output";
-	private const string FoldInputPropertyKeyPrefix = "_fold_input_property_";
-	private const string CustomWidthKey = "_custom_width";
+	// Internal because the dock's replay path writes these straight to the resource when no visual exists.
+	internal const string FoldInputKey = "_fold_input";
+	internal const string FoldOutputKey = "_fold_output";
+	internal const string FoldInputPropertyKeyPrefix = "_fold_input_property_";
+	internal const string CustomWidthKey = "_custom_width";
 
 	private static readonly Color _entryColor = new(0x2a4a8dff);
 	private static readonly Color _exitColor = new(0x8a549aff);
@@ -46,6 +47,7 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 	private StatescriptNodeDiscovery.NodeTypeInfo? _typeInfo;
 	private StatescriptGraph? _graph;
 	private EditorUndoRedoManager? _undoRedo;
+	private StatescriptGraphEditorDock? _replayHost;
 	private CustomNodeEditor? _activeCustomEditor;
 	private bool _resizeConnected;
 	private bool _refittingSize;
@@ -65,6 +67,13 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 	/// Gets the underlying node resource.
 	/// </summary>
 	public StatescriptNode? NodeResource { get; private set; }
+
+	/// <summary>
+	/// Gets the undo/redo manager only when a replay host and graph are wired, since per-node actions must be
+	/// registered on the host.
+	/// </summary>
+	private EditorUndoRedoManager? ReplayableUndoRedo =>
+		_replayHost is not null && _graph is not null ? _undoRedo : null;
 
 	public int VisualToRuntimeOutputPort(int visualPort)
 	{
@@ -87,6 +96,20 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 	public void SetUndoRedo(EditorUndoRedoManager? undoRedo)
 	{
 		_undoRedo = undoRedo;
+	}
+
+	/// <summary>
+	/// Sets the dock that hosts this node's undo/redo replay callbacks.
+	/// </summary>
+	/// <remarks>
+	/// Actions must never be registered on this visual: it is freed whenever the node is deleted, the tab closes, or
+	/// cached visuals are invalidated, and Godot silently skips do/undo operations whose target object is gone, which
+	/// broke redo across node re-creation. The dock outlives every visual.
+	/// </remarks>
+	/// <param name="replayHost">The dock owning this visual.</param>
+	public void SetReplayHost(StatescriptGraphEditorDock replayHost)
+	{
+		_replayHost = replayHost;
 	}
 
 	/// <summary>
@@ -279,6 +302,69 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		SetNodeConfigWithUndo(key, value, actionName, rebuildOnChange);
 	}
 
+	/// <summary>
+	/// Applies a node configuration change on this live visual during a replay.
+	/// </summary>
+	/// <remarks>
+	/// This and the sibling <c>Apply*Internal</c> methods are called by <c>StatescriptGraphEditorDock.NodeReplay</c>,
+	/// which owns the replay scope. They are never registered with the undo manager directly; see
+	/// <see cref="SetReplayHost"/>.
+	/// </remarks>
+	/// <param name="key">The CustomData key to restore.</param>
+	/// <param name="value">The value to restore, or a Nil variant to drop the key entirely.</param>
+	internal void ApplyNodeConfigInternal(string key, Variant value)
+	{
+		ApplyNodeConfigCore(key, value);
+	}
+
+	/// <summary>
+	/// Applies a width change on this live visual during a replay.
+	/// </summary>
+	/// <param name="width">The width to restore.</param>
+	internal void ApplyCustomWidthInternal(float width)
+	{
+		ApplyCustomWidthCore(width);
+	}
+
+	/// <summary>
+	/// Applies a resolver binding change on this live visual during a replay.
+	/// </summary>
+	/// <param name="directionInt">The direction of the property, as an int.</param>
+	/// <param name="propertyIndex">The index of the property.</param>
+	/// <param name="resolverVariant">The resolver to bind, or Nil to clear the binding.</param>
+	internal void ApplyResolverBindingInternal(int directionInt, int propertyIndex, Variant resolverVariant)
+	{
+		ApplyResolverBindingCore(directionInt, propertyIndex, resolverVariant);
+	}
+
+	/// <summary>
+	/// Applies an input-property config change on this live visual during a replay.
+	/// </summary>
+	/// <param name="customData">The CustomData entries to write.</param>
+	/// <param name="propertyIndex">The input slot being configured.</param>
+	/// <param name="resolverVariant">The resolver to bind, or Nil to clear the binding.</param>
+	internal void ApplyInputPropertyConfigInternal(
+		GodotCollections.Dictionary customData,
+		int propertyIndex,
+		Variant resolverVariant)
+	{
+		ApplyInputPropertyConfigCore(customData, propertyIndex, resolverVariant);
+	}
+
+	/// <summary>
+	/// Applies a port-layout config change on this live visual during a replay.
+	/// </summary>
+	/// <param name="customData">The CustomData entries to write.</param>
+	/// <param name="connectionsToRemove">Connections to detach before the node is laid out again.</param>
+	/// <param name="connectionsToAdd">Connections to attach once it has been.</param>
+	internal void ApplyLayoutConfigInternal(
+		GodotCollections.Dictionary customData,
+		GodotCollections.Array<StatescriptConnection> connectionsToRemove,
+		GodotCollections.Array<StatescriptConnection> connectionsToAdd)
+	{
+		ApplyLayoutConfigCore(customData, connectionsToRemove, connectionsToAdd);
+	}
+
 	internal StatescriptNodeProperty? FindBindingInternal(
 		StatescriptPropertyDirection direction,
 		int propertyIndex)
@@ -307,21 +393,32 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		StatescriptResolverResource? newResolver,
 		string actionName)
 	{
+		if (NodeResource is null)
+		{
+			return;
+		}
+
+		string nodeId = NodeResource.NodeId;
+
 		EditorUndoRedoUtils.Record(
-			_undoRedo,
+			ReplayableUndoRedo,
 			actionName,
 			_graph,
 			undo =>
 			{
 				undo.AddDoMethod(
-					this,
-					MethodName.ApplyResolverBinding,
+					_replayHost!,
+					StatescriptGraphEditorDock.MethodName.ReplayResolverBinding,
+					_graph!,
+					nodeId,
 					(int)direction,
 					propertyIndex,
 					Variant.From(newResolver));
 				undo.AddUndoMethod(
-					this,
-					MethodName.ApplyResolverBinding,
+					_replayHost!,
+					StatescriptGraphEditorDock.MethodName.ReplayResolverBinding,
+					_graph!,
+					nodeId,
 					(int)direction,
 					propertyIndex,
 					Variant.From(oldResolver));
@@ -790,16 +887,26 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		Variant capturedOld = had ? oldValue : default;
 		bool hadOld = had;
 
+		string nodeId = NodeResource.NodeId;
+
 		EditorUndoRedoUtils.Record(
-			_undoRedo,
+			ReplayableUndoRedo,
 			actionName,
 			_graph,
 			undo =>
 			{
-				undo.AddDoMethod(this, MethodName.ApplyNodeConfig, key, value);
+				undo.AddDoMethod(
+					_replayHost!,
+					StatescriptGraphEditorDock.MethodName.ReplayNodeConfig,
+					_graph!,
+					nodeId,
+					key,
+					value);
 				undo.AddUndoMethod(
-					this,
-					MethodName.ApplyNodeConfig,
+					_replayHost!,
+					StatescriptGraphEditorDock.MethodName.ReplayNodeConfig,
+					_graph!,
+					nodeId,
 					key,
 					hadOld ? capturedOld : Variant.From<GodotObject?>(null));
 			});
@@ -812,20 +919,17 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 	}
 
 	/// <summary>
-	/// Replays a node configuration change for undo/redo. Only ever invoked from the undo manager: the user's own edit
-	/// writes <c>CustomData</c> directly and records the action without executing it.
+	/// Applies a node configuration change and rebuilds the node.
 	/// </summary>
 	/// <remarks>
-	/// The node is always rebuilt afterwards. The control showing this value (an attribute picker, an enum dropdown, a
-	/// checkbox) reads <c>CustomData</c> only while it is being built, so skipping the rebuild would restore the data
-	/// while leaving the old selection on screen — and the next save would then persist whatever the stale UI shows.
+	/// The rebuild is not optional. The control showing this value reads <c>CustomData</c> only while being built, so
+	/// skipping it would restore the data while leaving the old selection on screen, and the next save would then
+	/// persist whatever the stale UI shows.
 	/// </remarks>
 	/// <param name="key">The CustomData key to restore.</param>
 	/// <param name="value">The value to restore, or a Nil variant to drop the key entirely.</param>
-	private void ApplyNodeConfig(string key, Variant value)
+	private void ApplyNodeConfigCore(string key, Variant value)
 	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
 		if (NodeResource is null)
 		{
 			return;
@@ -858,25 +962,34 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		if (NodeResource is not null && !Mathf.IsEqualApprox(_widthBeforeResize, newWidth))
 		{
 			float oldWidth = _widthBeforeResize;
+			string nodeId = NodeResource.NodeId;
 
 			EditorUndoRedoUtils.Record(
-				_undoRedo,
+				ReplayableUndoRedo,
 				"Resize Node",
 				_graph,
 				undo =>
 				{
-					undo.AddDoMethod(this, MethodName.ApplyCustomWidth, newWidth);
-					undo.AddUndoMethod(this, MethodName.ApplyCustomWidth, oldWidth);
+					undo.AddDoMethod(
+						_replayHost!,
+						StatescriptGraphEditorDock.MethodName.ReplayNodeWidth,
+						_graph!,
+						nodeId,
+						newWidth);
+					undo.AddUndoMethod(
+						_replayHost!,
+						StatescriptGraphEditorDock.MethodName.ReplayNodeWidth,
+						_graph!,
+						nodeId,
+						oldWidth);
 				});
 		}
 
 		_widthBeforeResize = newWidth;
 	}
 
-	private void ApplyCustomWidth(float width)
+	private void ApplyCustomWidthCore(float width)
 	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
 		CustomMinimumSize = new Vector2(width, 0);
 		Size = new Vector2(width, 0);
 		SaveCustomWidth(width);
@@ -907,13 +1020,11 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		NotifyGraphResourceChanged();
 	}
 
-	private void ApplyResolverBinding(
+	private void ApplyResolverBindingCore(
 		int directionInt,
 		int propertyIndex,
 		Variant resolverVariant)
 	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
 		if (NodeResource is null)
 		{
 			return;
@@ -999,21 +1110,27 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		// new type.
 		ApplyInputPropertyConfigCore(newData, propertyIndex, default);
 
+		string nodeId = NodeResource.NodeId;
+
 		EditorUndoRedoUtils.Record(
-			_undoRedo,
+			ReplayableUndoRedo,
 			pending.ActionName,
 			_graph,
 			undo =>
 			{
 				undo.AddDoMethod(
-					this,
-					MethodName.ApplyInputPropertyConfig,
+					_replayHost!,
+					StatescriptGraphEditorDock.MethodName.ReplayInputPropertyConfig,
+					_graph!,
+					nodeId,
 					newData,
 					propertyIndex,
 					Variant.From((StatescriptResolverResource?)null));
 				undo.AddUndoMethod(
-					this,
-					MethodName.ApplyInputPropertyConfig,
+					_replayHost!,
+					StatescriptGraphEditorDock.MethodName.ReplayInputPropertyConfig,
+					_graph!,
+					nodeId,
 					oldData,
 					propertyIndex,
 					Variant.From(oldResolver));
@@ -1063,15 +1180,31 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		// The core, not the replay wrapper: as a replay this would suppress the bindings the rebuild seeds.
 		ApplyLayoutConfigCore(newData, connectionsToRemove, connectionsToAdd);
 
+		string nodeId = NodeResource.NodeId;
+
 		// Undo is the same operation mirrored: restore the old configuration and swap the two connection sets back.
 		EditorUndoRedoUtils.Record(
-			_undoRedo,
+			ReplayableUndoRedo,
 			pending.ActionName,
 			_graph,
 			undo =>
 			{
-				undo.AddDoMethod(this, MethodName.ApplyLayoutConfig, newData, connectionsToRemove, connectionsToAdd);
-				undo.AddUndoMethod(this, MethodName.ApplyLayoutConfig, oldData, connectionsToAdd, connectionsToRemove);
+				undo.AddDoMethod(
+					_replayHost!,
+					StatescriptGraphEditorDock.MethodName.ReplayLayoutConfig,
+					_graph!,
+					nodeId,
+					newData,
+					connectionsToRemove,
+					connectionsToAdd);
+				undo.AddUndoMethod(
+					_replayHost!,
+					StatescriptGraphEditorDock.MethodName.ReplayLayoutConfig,
+					_graph!,
+					nodeId,
+					oldData,
+					connectionsToAdd,
+					connectionsToRemove);
 			});
 
 		PropertyBindingChanged?.Invoke();
@@ -1173,16 +1306,6 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 	/// <param name="customData">The CustomData entries to write.</param>
 	/// <param name="connectionsToRemove">Connections to detach before the node is laid out again.</param>
 	/// <param name="connectionsToAdd">Connections to attach once it has been.</param>
-	private void ApplyLayoutConfig(
-		GodotCollections.Dictionary customData,
-		GodotCollections.Array<StatescriptConnection> connectionsToRemove,
-		GodotCollections.Array<StatescriptConnection> connectionsToAdd)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		ApplyLayoutConfigCore(customData, connectionsToRemove, connectionsToAdd);
-	}
-
 	private void ApplyLayoutConfigCore(
 		GodotCollections.Dictionary customData,
 		GodotCollections.Array<StatescriptConnection> connectionsToRemove,
@@ -1274,23 +1397,6 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 
 			NodeResource.CustomData[key] = entry.Value;
 		}
-	}
-
-	/// <summary>
-	/// Undo/redo entry point for an input-property config change. Only the replay goes through here; the user's own
-	/// edit calls <see cref="ApplyInputPropertyConfigCore"/> directly so it is not mistaken for a replay.
-	/// </summary>
-	/// <param name="customData">The CustomData entries to write.</param>
-	/// <param name="propertyIndex">The input slot being configured.</param>
-	/// <param name="resolverVariant">The resolver to bind, or Nil to clear the binding.</param>
-	private void ApplyInputPropertyConfig(
-		GodotCollections.Dictionary customData,
-		int propertyIndex,
-		Variant resolverVariant)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		ApplyInputPropertyConfigCore(customData, propertyIndex, resolverVariant);
 	}
 
 	private void ApplyInputPropertyConfigCore(

--- a/addons/forge/editor/statescript/StatescriptGraphNode.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.cs
@@ -810,34 +810,42 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		Variant capturedOld = had ? oldValue : default;
 		bool hadOld = had;
 
-		// Layout-affecting config rebuilds the node on do/undo/redo so shown/hidden rows track the value; other config
-		// just persists the value in place.
-		StringName applyMethod = rebuildOnChange ? MethodName.ApplyNodeConfigAndRebuild : MethodName.ApplyNodeConfig;
-
 		EditorUndoRedoUtils.Record(
 			_undoRedo,
 			actionName,
 			_graph,
 			undo =>
 			{
-				undo.AddDoMethod(this, applyMethod, key, value);
+				undo.AddDoMethod(this, MethodName.ApplyNodeConfig, key, value);
 				undo.AddUndoMethod(
 					this,
-					applyMethod,
+					MethodName.ApplyNodeConfig,
 					key,
 					hadOld ? capturedOld : Variant.From<GodotObject?>(null));
 			});
 
+		// Deferred so the control still emitting this change is not freed mid-signal. Replays rebuild unconditionally.
 		if (rebuildOnChange)
 		{
-			// The value is already applied above; the deferred rebuild reflects it without freeing the dropdown or
-			// checkbox that is still emitting the change signal.
 			Callable.From(RebuildNode).CallDeferred();
 		}
 	}
 
+	/// <summary>
+	/// Replays a node configuration change for undo/redo. Only ever invoked from the undo manager: the user's own edit
+	/// writes <c>CustomData</c> directly and records the action without executing it.
+	/// </summary>
+	/// <remarks>
+	/// The node is always rebuilt afterwards. The control showing this value (an attribute picker, an enum dropdown, a
+	/// checkbox) reads <c>CustomData</c> only while it is being built, so skipping the rebuild would restore the data
+	/// while leaving the old selection on screen — and the next save would then persist whatever the stale UI shows.
+	/// </remarks>
+	/// <param name="key">The CustomData key to restore.</param>
+	/// <param name="value">The value to restore, or a Nil variant to drop the key entirely.</param>
 	private void ApplyNodeConfig(string key, Variant value)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (NodeResource is null)
 		{
 			return;
@@ -853,11 +861,6 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		}
 
 		NotifyGraphResourceChanged();
-	}
-
-	private void ApplyNodeConfigAndRebuild(string key, Variant value)
-	{
-		ApplyNodeConfig(key, value);
 		RebuildNode();
 	}
 

--- a/addons/forge/editor/statescript/StatescriptGraphNode.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.cs
@@ -269,9 +269,9 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		return GetFoldState(key, defaultValue);
 	}
 
-	internal void SetFoldStateWithUndoInternal(string key, bool folded)
+	internal void PersistFoldStateInternal(string key, bool folded)
 	{
-		SetFoldStateWithUndo(key, folded);
+		PersistFoldState(key, folded);
 	}
 
 	internal void SetNodeConfigWithUndoInternal(string key, Variant value, string actionName, bool rebuildOnChange)
@@ -664,7 +664,7 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 			bool stored = GetFoldState(kvp.Value);
 			if (kvp.Key.Folded != stored)
 			{
-				SetFoldStateWithUndo(kvp.Value, kvp.Key.Folded);
+				PersistFoldState(kvp.Value, kvp.Key.Folded);
 			}
 		}
 
@@ -755,39 +755,19 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		NotifyGraphResourceChanged();
 	}
 
-	private void SetFoldStateWithUndo(string key, bool folded)
+	/// <summary>
+	/// Persists a section's fold state without recording an undo step, since folding is view state.
+	/// </summary>
+	/// <param name="key">The CustomData key holding this section's fold state.</param>
+	/// <param name="folded">The new folded state.</param>
+	private void PersistFoldState(string key, bool folded)
 	{
-		if (NodeResource is null)
-		{
-			return;
-		}
-
-		bool oldFolded = GetFoldState(key);
-
-		if (oldFolded == folded)
+		if (NodeResource is null || GetFoldState(key) == folded)
 		{
 			return;
 		}
 
 		SetFoldState(key, folded);
-
-		EditorUndoRedoUtils.Record(
-			_undoRedo,
-			"Toggle Fold",
-			_graph,
-			undo =>
-			{
-				undo.AddDoMethod(this, MethodName.ApplyFoldState, key, folded);
-				undo.AddUndoMethod(this, MethodName.ApplyFoldState, key, oldFolded);
-			});
-	}
-
-	private void ApplyFoldState(string key, bool folded)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		SetFoldState(key, folded);
-		RebuildNode();
 	}
 
 	private void SetNodeConfigWithUndo(string key, Variant value, string actionName, bool rebuildOnChange)

--- a/addons/forge/editor/statescript/StatescriptGraphNode.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.cs
@@ -378,6 +378,12 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 			return;
 		}
 
+		// The flush records, and being deferred it would run after the replay scope closed, committing a stray action.
+		if (EditorUndoRedoUtils.IsReplaying)
+		{
+			return;
+		}
+
 		// Merge into any change already queued for this slot this frame so none is lost before the deferred flush.
 		if (_pendingInputConfigs.TryGetValue(propertyIndex, out PendingInputConfig? pending))
 		{
@@ -408,6 +414,12 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 	internal void ChangeNodeLayoutConfigInternal(GodotCollections.Dictionary customData, string actionName)
 	{
 		if (NodeResource is null)
+		{
+			return;
+		}
+
+		// See ChangeInputPropertyConfigInternal: a replay-driven rebuild must not queue a recording flush.
+		if (EditorUndoRedoUtils.IsReplaying)
 		{
 			return;
 		}
@@ -772,6 +784,8 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 
 	private void ApplyFoldState(string key, bool folded)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		SetFoldState(key, folded);
 		RebuildNode();
 	}
@@ -878,6 +892,8 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 
 	private void ApplyCustomWidth(float width)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		CustomMinimumSize = new Vector2(width, 0);
 		Size = new Vector2(width, 0);
 		SaveCustomWidth(width);
@@ -913,6 +929,8 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		int propertyIndex,
 		Variant resolverVariant)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (NodeResource is null)
 		{
 			return;
@@ -994,7 +1012,9 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 			as StatescriptResolverResource;
 
 		// Changing an input's type/shape invalidates its resolver, so the binding is reset (passing a Nil resolver).
-		ApplyInputPropertyConfig(newData, propertyIndex, default);
+		// The core, not the replay wrapper: as a replay this would suppress the binding the rebuild seeds for the
+		// new type.
+		ApplyInputPropertyConfigCore(newData, propertyIndex, default);
 
 		EditorUndoRedoUtils.Record(
 			_undoRedo,
@@ -1057,7 +1077,8 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		var connectionsToAdd = new GodotCollections.Array<StatescriptConnection>();
 		CollectConnectionChanges(newData, connectionsToRemove, connectionsToAdd);
 
-		ApplyLayoutConfig(newData, connectionsToRemove, connectionsToAdd);
+		// The core, not the replay wrapper: as a replay this would suppress the bindings the rebuild seeds.
+		ApplyLayoutConfigCore(newData, connectionsToRemove, connectionsToAdd);
 
 		// Undo is the same operation mirrored: restore the old configuration and swap the two connection sets back.
 		EditorUndoRedoUtils.Record(
@@ -1174,6 +1195,16 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		GodotCollections.Array<StatescriptConnection> connectionsToRemove,
 		GodotCollections.Array<StatescriptConnection> connectionsToAdd)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		ApplyLayoutConfigCore(customData, connectionsToRemove, connectionsToAdd);
+	}
+
+	private void ApplyLayoutConfigCore(
+		GodotCollections.Dictionary customData,
+		GodotCollections.Array<StatescriptConnection> connectionsToRemove,
+		GodotCollections.Array<StatescriptConnection> connectionsToAdd)
+	{
 		SetVisualConnections(connectionsToRemove, connected: false);
 
 		foreach (StatescriptConnection connection in connectionsToRemove)
@@ -1262,7 +1293,24 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 		}
 	}
 
+	/// <summary>
+	/// Undo/redo entry point for an input-property config change. Only the replay goes through here; the user's own
+	/// edit calls <see cref="ApplyInputPropertyConfigCore"/> directly so it is not mistaken for a replay.
+	/// </summary>
+	/// <param name="customData">The CustomData entries to write.</param>
+	/// <param name="propertyIndex">The input slot being configured.</param>
+	/// <param name="resolverVariant">The resolver to bind, or Nil to clear the binding.</param>
 	private void ApplyInputPropertyConfig(
+		GodotCollections.Dictionary customData,
+		int propertyIndex,
+		Variant resolverVariant)
+	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
+		ApplyInputPropertyConfigCore(customData, propertyIndex, resolverVariant);
+	}
+
+	private void ApplyInputPropertyConfigCore(
 		GodotCollections.Dictionary customData,
 		int propertyIndex,
 		Variant resolverVariant)

--- a/addons/forge/editor/statescript/StatescriptGraphNode.cs
+++ b/addons/forge/editor/statescript/StatescriptGraphNode.cs
@@ -356,7 +356,7 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 	/// </summary>
 	/// <param name="customData">The CustomData entries to write.</param>
 	/// <param name="connectionsToRemove">Connections to detach before the node is laid out again.</param>
-	/// <param name="connectionsToAdd">Connections to attach once it has been.</param>
+	/// <param name="connectionsToAdd">Connections to attach after the node has been laid out.</param>
 	internal void ApplyLayoutConfigInternal(
 		GodotCollections.Dictionary customData,
 		GodotCollections.Array<StatescriptConnection> connectionsToRemove,
@@ -1305,7 +1305,7 @@ public partial class StatescriptGraphNode : GraphNode, ISerializationListener
 	/// </summary>
 	/// <param name="customData">The CustomData entries to write.</param>
 	/// <param name="connectionsToRemove">Connections to detach before the node is laid out again.</param>
-	/// <param name="connectionsToAdd">Connections to attach once it has been.</param>
+	/// <param name="connectionsToAdd">Connections to attach after the node has been laid out.</param>
 	private void ApplyLayoutConfigCore(
 		GodotCollections.Dictionary customData,
 		GodotCollections.Array<StatescriptConnection> connectionsToRemove,

--- a/addons/forge/editor/statescript/StatescriptVariablePanel.UndoRedoCallbacks.cs
+++ b/addons/forge/editor/statescript/StatescriptVariablePanel.UndoRedoCallbacks.cs
@@ -196,23 +196,5 @@ internal sealed partial class StatescriptVariablePanel
 			SaveExpandedArrayState();
 		}
 	}
-
-	private void DoSetArrayExpanded(string variableName, bool expanded)
-	{
-		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
-
-		if (expanded)
-		{
-			_expandedArrays.Add(variableName);
-		}
-		else
-		{
-			_expandedArrays.Remove(variableName);
-		}
-
-		SaveExpandedArrayState();
-		RebuildList();
-		VariableUndoRedoPerformed?.Invoke();
-	}
 }
 #endif

--- a/addons/forge/editor/statescript/StatescriptVariablePanel.UndoRedoCallbacks.cs
+++ b/addons/forge/editor/statescript/StatescriptVariablePanel.UndoRedoCallbacks.cs
@@ -38,6 +38,8 @@ internal sealed partial class StatescriptVariablePanel
 
 	private void ApplyArrayElementValue(StatescriptGraphVariable variable, int index, Variant value)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (index >= 0 && index < variable.InitialArrayValues.Count)
 		{
 			variable.InitialArrayValues[index] = value;
@@ -71,6 +73,8 @@ internal sealed partial class StatescriptVariablePanel
 
 	private void ApplyVariableValue(StatescriptGraphVariable variable, Variant value)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		variable.InitialValue = value;
 		variable.EmitChanged();
 		RebuildList();
@@ -79,6 +83,8 @@ internal sealed partial class StatescriptVariablePanel
 
 	private void DoAddVariable(StatescriptGraph graph, StatescriptGraphVariable variable)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		graph.Variables.Add(variable);
 		RebuildList();
 		VariablesChanged?.Invoke();
@@ -86,6 +92,8 @@ internal sealed partial class StatescriptVariablePanel
 
 	private void UndoAddVariable(StatescriptGraph graph, StatescriptGraphVariable variable)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		graph.Variables.Remove(variable);
 		RebuildList();
 		VariablesChanged?.Invoke();
@@ -94,6 +102,8 @@ internal sealed partial class StatescriptVariablePanel
 
 	private void DoRemoveVariable(StatescriptGraph graph, StatescriptGraphVariable variable, int index)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (_selectedVariableName == variable.VariableName)
 		{
 			_selectedVariableName = null;
@@ -108,6 +118,8 @@ internal sealed partial class StatescriptVariablePanel
 
 	private void UndoRemoveVariable(StatescriptGraph graph, StatescriptGraphVariable variable, int index)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (index >= graph.Variables.Count)
 		{
 			graph.Variables.Add(variable);
@@ -124,6 +136,8 @@ internal sealed partial class StatescriptVariablePanel
 
 	private void DoAddArrayElement(StatescriptGraphVariable variable, Variant value)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		variable.InitialArrayValues.Add(value);
 		variable.EmitChanged();
 		EnsureArrayExpanded(variable.VariableName);
@@ -132,6 +146,8 @@ internal sealed partial class StatescriptVariablePanel
 
 	private void UndoAddArrayElement(StatescriptGraphVariable variable)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (variable.InitialArrayValues.Count > 0)
 		{
 			variable.InitialArrayValues.RemoveAt(variable.InitialArrayValues.Count - 1);
@@ -145,6 +161,8 @@ internal sealed partial class StatescriptVariablePanel
 
 	private void DoRemoveArrayElement(StatescriptGraphVariable variable, int index)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		variable.InitialArrayValues.RemoveAt(index);
 		variable.EmitChanged();
 		RebuildList();
@@ -152,6 +170,8 @@ internal sealed partial class StatescriptVariablePanel
 
 	private void UndoRemoveArrayElement(StatescriptGraphVariable variable, int index, Variant value)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (index >= variable.InitialArrayValues.Count)
 		{
 			variable.InitialArrayValues.Add(value);
@@ -179,6 +199,8 @@ internal sealed partial class StatescriptVariablePanel
 
 	private void DoSetArrayExpanded(string variableName, bool expanded)
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (expanded)
 		{
 			_expandedArrays.Add(variableName);

--- a/addons/forge/editor/statescript/StatescriptVariablePanel.ValueEditors.cs
+++ b/addons/forge/editor/statescript/StatescriptVariablePanel.ValueEditors.cs
@@ -106,8 +106,6 @@ internal sealed partial class StatescriptVariablePanel
 		{
 			elementsContainer.Visible = x;
 
-			bool wasExpanded = !x;
-
 			if (x)
 			{
 				_expandedArrays.Add(variable.VariableName);
@@ -117,17 +115,8 @@ internal sealed partial class StatescriptVariablePanel
 				_expandedArrays.Remove(variable.VariableName);
 			}
 
+			// Persisted but not recorded: expanding a row is view state, same as a collapsed foldable.
 			SaveExpandedArrayState();
-
-			EditorUndoRedoUtils.Record(
-				_undoRedo,
-				"Toggle Array Expand",
-				_graph,
-				undo =>
-				{
-					undo.AddDoMethod(this, MethodName.DoSetArrayExpanded, variable.VariableName, x);
-					undo.AddUndoMethod(this, MethodName.DoSetArrayExpanded, variable.VariableName, wasExpanded);
-				});
 		};
 
 		headerRow.AddChild(toggleButton);

--- a/addons/forge/editor/statescript/node_editors/DebugNodeEditor.cs
+++ b/addons/forge/editor/statescript/node_editors/DebugNodeEditor.cs
@@ -150,7 +150,7 @@ internal sealed partial class DebugNodeEditor : CustomNodeEditor
 
 	private void OnTypeFoldableFoldingChanged(bool folded)
 	{
-		SetFoldStateWithUndo(TypeFoldKey, folded);
+		PersistFoldState(TypeFoldKey, folded);
 		UpdateTypeFoldableTitle();
 		RefreshInputPropertyFoldableTitles();
 		ResetSize();

--- a/addons/forge/editor/statescript/node_editors/EventListenerNodeEditor.cs
+++ b/addons/forge/editor/statescript/node_editors/EventListenerNodeEditor.cs
@@ -238,7 +238,7 @@ internal sealed partial class EventListenerNodeEditor : CustomNodeEditor
 
 		_payloadFoldable.FoldingChanged += folded =>
 		{
-			SetFoldStateWithUndo(PayloadFoldKey, folded);
+			PersistFoldState(PayloadFoldKey, folded);
 			UpdatePayloadBadge();
 			RaisePropertyBindingChanged();
 			ResetSize();

--- a/addons/forge/editor/statescript/node_editors/NodeConfigParam.cs
+++ b/addons/forge/editor/statescript/node_editors/NodeConfigParam.cs
@@ -21,7 +21,8 @@ namespace Gamesmiths.Forge.Godot.Editor.Statescript.NodeEditors;
 /// <param name="DefaultBool">The default boolean value, used when no value is stored yet.</param>
 /// <param name="AffectsLayout">When <see langword="true"/>, changing this parameter rebuilds the node so an editor
 /// that shows or hides input rows based on it (see <see cref="StandardNodeEditorBase.IsInputVisible"/>) updates
-/// immediately. Leave <see langword="false"/> for config that does not change which rows are rendered.</param>
+/// immediately. Leave <see langword="false"/> for config that does not change which rows are rendered. This only
+/// affects the user's own edit; undo and redo always rebuild so the control re-reads the restored value.</param>
 internal readonly record struct NodeConfigParam(
 	string Key,
 	string Label,

--- a/addons/forge/editor/statescript/node_editors/SetVariableNodeEditor.cs
+++ b/addons/forge/editor/statescript/node_editors/SetVariableNodeEditor.cs
@@ -828,7 +828,7 @@ internal sealed partial class SetVariableNodeEditor : CustomNodeEditor
 
 	private void OnScopeFoldableFoldingChanged(bool folded)
 	{
-		SetFoldStateWithUndo(ScopeFoldKey, folded);
+		PersistFoldState(ScopeFoldKey, folded);
 		UpdateScopeFoldableTitle();
 		RaisePropertyBindingChanged();
 		ResetSize();
@@ -836,7 +836,7 @@ internal sealed partial class SetVariableNodeEditor : CustomNodeEditor
 
 	private void OnTargetFoldableFoldingChanged(bool folded)
 	{
-		SetFoldStateWithUndo(TargetFoldKey, folded);
+		PersistFoldState(TargetFoldKey, folded);
 
 		if (_cachedTypeInfo?.OutputVariablesInfo.Length > 0)
 		{

--- a/addons/forge/editor/statescript/resolvers/ArrayResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/ArrayResolverEditor.cs
@@ -492,7 +492,7 @@ internal sealed partial class ArrayResolverEditor : NodeEditorProperty
 
 		_elementFoldedStates[elementIndex] = _elementFoldables[elementIndex].Folded;
 		UpdateElementFoldableTitle(elementIndex);
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/ComparisonResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/ComparisonResolverEditor.cs
@@ -198,14 +198,14 @@ internal sealed partial class ComparisonResolverEditor : NodeEditorProperty
 	private void OnFoldingChanged(bool isFolded)
 	{
 		UpdateFoldableTitles();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 
 	private void OnOperationFoldableFoldingChanged(bool isFolded)
 	{
 		UpdateOperationFoldableTitle();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/EffectResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/EffectResolverEditor.cs
@@ -307,7 +307,8 @@ internal sealed partial class EffectResolverEditor : NodeEditorProperty
 
 	private void OnFoldableChanged(bool folded)
 	{
-		NotifyChanged();
+		UpdateFoldableTitles();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/EulerAnglesFromQuaternionResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/EulerAnglesFromQuaternionResolverEditor.cs
@@ -119,7 +119,7 @@ internal sealed partial class EulerAnglesFromQuaternionResolverEditor : NodeEdit
 	private void OnOperandFoldableFoldingChanged(bool folded)
 	{
 		UpdateOperandFoldableTitle();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/OwnershipResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/OwnershipResolverEditor.cs
@@ -158,7 +158,7 @@ internal sealed partial class OwnershipResolverEditor : NodeEditorProperty
 	private void OnFoldableChanged(bool isFolded)
 	{
 		UpdateFoldableTitles();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/QuaternionFromEulerAnglesResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/QuaternionFromEulerAnglesResolverEditor.cs
@@ -119,7 +119,7 @@ internal sealed partial class QuaternionFromEulerAnglesResolverEditor : NodeEdit
 	private void OnOperandFoldableFoldingChanged(bool folded)
 	{
 		UpdateOperandFoldableTitle();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/RandomResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/RandomResolverEditor.cs
@@ -321,14 +321,14 @@ internal sealed partial class RandomResolverEditor : NodeEditorProperty
 	private void OnInclusiveMaxFoldableFoldingChanged(bool folded)
 	{
 		UpdateInclusiveMaxFoldableTitle();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 
 	private void OnResolverSlotFoldableFoldingChanged(bool folded)
 	{
 		UpdateFoldableTitles();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/RoundResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/RoundResolverEditor.cs
@@ -151,7 +151,7 @@ internal sealed partial class RoundResolverEditor : NodeEditorProperty
 	private void OnFoldingChanged(bool isFolded)
 	{
 		UpdateFoldableTitle();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/SignedAngleResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/SignedAngleResolverEditor.cs
@@ -327,7 +327,7 @@ internal sealed partial class SignedAngleResolverEditor : NodeEditorProperty
 	private void OnFoldingChanged(bool isFolded)
 	{
 		UpdateFoldableTitles();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/VectorComponentResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/VectorComponentResolverEditor.cs
@@ -165,7 +165,7 @@ internal sealed partial class VectorComponentResolverEditor : NodeEditorProperty
 	private void OnOperandFoldableFoldingChanged(bool folded)
 	{
 		UpdateOperandFoldableTitle();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/VectorFromValuesResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/VectorFromValuesResolverEditor.cs
@@ -373,7 +373,7 @@ internal sealed partial class VectorFromValuesResolverEditor : NodeEditorPropert
 	private void OnComponentFoldableFoldingChanged(bool folded)
 	{
 		UpdateFoldableTitles();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/bases/AsymmetricBinaryNestedResolverEditorBase.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/AsymmetricBinaryNestedResolverEditorBase.cs
@@ -180,7 +180,7 @@ internal abstract partial class AsymmetricBinaryNestedResolverEditorBase<TResour
 	private void OnFoldingChanged(bool isFolded)
 	{
 		UpdateFoldableTitles();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/bases/BinaryNestedResolverEditorBase.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/BinaryNestedResolverEditorBase.cs
@@ -218,7 +218,7 @@ internal abstract partial class BinaryNestedResolverEditorBase<TResource> : Node
 	private void OnFoldingChanged(bool isFolded)
 	{
 		UpdateFoldableTitles();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/bases/NestedResolverPicker.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/NestedResolverPicker.cs
@@ -162,7 +162,13 @@ internal sealed partial class NestedResolverPicker : VBoxContainer
 	private void OnFoldingChanged(bool isFolded)
 	{
 		UpdateFoldableTitle();
-		_onChanged?.Invoke();
+
+		// Persisted but not recorded: collapsing the picker is view state.
+		using (EditorUndoRedoUtils.EnterViewStateChange())
+		{
+			_onChanged?.Invoke();
+		}
+
 		_layoutSizeChanged?.Invoke();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/bases/TernaryNestedResolverEditorBase.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/TernaryNestedResolverEditorBase.cs
@@ -314,7 +314,7 @@ internal abstract partial class TernaryNestedResolverEditorBase<TResource> : Nod
 	private void OnFoldableFoldingChanged(bool folded)
 	{
 		UpdateFoldableTitles();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/statescript/resolvers/bases/UnaryNestedResolverEditorBase.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/UnaryNestedResolverEditorBase.cs
@@ -140,7 +140,7 @@ internal abstract partial class UnaryNestedResolverEditorBase<TResource> : NodeE
 	private void OnFoldingChanged(bool isFolded)
 	{
 		UpdateFoldableTitle();
-		_onChanged?.Invoke();
+		SaveViewState(_onChanged);
 		RaiseLayoutSizeChanged();
 	}
 

--- a/addons/forge/editor/tags/TagSourceEditingController.cs
+++ b/addons/forge/editor/tags/TagSourceEditingController.cs
@@ -104,6 +104,8 @@ public sealed partial class TagSourceEditingController : Node
 	public void PersistSource(ForgeTagsSource source)
 #pragma warning restore CA1822, S2325
 	{
+		using EditorUndoRedoUtils.ReplayScope replay = EditorUndoRedoUtils.EnterReplay();
+
 		if (string.IsNullOrEmpty(source.ResourcePath))
 		{
 			GD.PushError("This tag source has never been saved, so its tags cannot be written anywhere.");


### PR DESCRIPTION
## Summary
Prevent undo/redo replay from recording new actions by adding EditorUndoRedoUtils.IsReplaying and EnterReplay() scope; make() no-op during replay skip flushes scheduled during replay.

- Ensure Settings controls refresh on undo/redo always in ApplyNodeConfig so reflects restored CustomData.
- Stop node rebuilds from mutating graph resources during replay by skipping writes that seed bindings while replay in.
- Make deleting multiple nodes a single undo step by recording one action for selection and mut graph.Connections directly.
- Exclude view state (fold/expand) changes from the undo stack; introduce PersistFoldState and EnterViewStateChange() scope for resolver fold writes- Surface undo recording failures and recover by warning when no undo manager available and resetting scope depth when plugin enters tree.
- per-node undo on long-lived dock (keyed by graph,node) instead of transient visuals so actions survive node deletion, switches, and visual recreation- Host shared variable set undo on a long-lived SharedVariableSetEditingController inspectores don't orphan undo callbacks; scope actions to edited set and make add/remove inverses explicitChecklist- Tests added or updated: N/A (es behavior regressions observed in UI)
- Documentation updated N/ANotes for reviewers- Key helper: EditorUndoRedoUtils.EnterReplay()/Isplaying and EnterViewStateChange() scopes control recordings are suppressed or allowed.
- Per-node shared actions now target-lived controllers ( or controller) and resolve live visuals replay time.