### PR TITLE
Fixed statescript property labels overflowing on node creation and Godot startup.

### DIFF
--- a/addons/forge/editor/statescript/InlineConstantSummaryFormatter.cs
+++ b/addons/forge/editor/statescript/InlineConstantSummaryFormatter.cs
@@ -648,6 +648,8 @@ internal static class InlineConstantSummaryFormatter
 			badge.CustomMinimumSize = new Vector2(
 				Math.Max(MinimumBadgeWidth, RowContentWidth(columned) - labelColumnWidth),
 				0);
+
+			columned.QueueRedraw();
 		}
 	}
 


### PR DESCRIPTION
## Summary
Fix an issue where FoldableContainer's could spill under summary pill because the row wasn't repainted when its minimum changed.

<img width="542" height="544" alt="image" src="https://github.com/user-attachments/assets/3d537b3c-c27a-4099-aee0-07685b24392b" />
