### PR TITLE
Fixed error caused by variable row being freed mid signal.

### DIFF
--- a/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
+++ b/addons/forge/editor/statescript/SharedVariableSetEditorProperty.cs
@@ -281,7 +281,7 @@ internal sealed partial class SharedVariableSetEditorProperty : EditorProperty, 
 		foreach (Node child in _variableList.GetChildren())
 		{
 			_variableList.RemoveChild(child);
-			child.Free();
+			child.QueueFree();
 		}
 	}
 

--- a/addons/forge/editor/statescript/StatescriptVariablePanel.cs
+++ b/addons/forge/editor/statescript/StatescriptVariablePanel.cs
@@ -278,7 +278,7 @@ internal sealed partial class StatescriptVariablePanel : VBoxContainer, ISeriali
 		foreach (Node child in _variableList.GetChildren())
 		{
 			_variableList.RemoveChild(child);
-			child.Free();
+			child.QueueFree();
 		}
 	}
 


### PR DESCRIPTION
Fixed editor log error caused when deleting variables.