### PR TITLE
Added statescript input and camera nodes and resolvers.

### DIFF
--- a/addons/forge/core/statescript/nodes/state/InputActionNode.cs
+++ b/addons/forge/core/statescript/nodes/state/InputActionNode.cs
@@ -46,7 +46,7 @@ public class InputActionNode(string actionName = "", bool deactivateOnPressed = 
 	/// </summary>
 	public const byte WhilePressedPort = 6;
 
-	private readonly string _actionName = actionName ?? string.Empty;
+	private readonly StringName _actionName = actionName ?? string.Empty;
 	private readonly bool _deactivateOnPressed = deactivateOnPressed;
 
 	private bool _reportedMissingAction;

--- a/addons/forge/core/statescript/nodes/state/InputActionNode.cs
+++ b/addons/forge/core/statescript/nodes/state/InputActionNode.cs
@@ -1,0 +1,148 @@
+// Copyright © Gamesmiths Guild.
+
+using System.Collections.Generic;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Nodes;
+using Gamesmiths.Forge.Statescript.Ports;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Core.Statescript.Nodes.State;
+
+/// <summary>
+/// State node that watches a button while active, reporting when it is pressed and released.
+/// </summary>
+/// <remarks>
+/// <para>This is the "wait for a button before continuing" node. <see cref="WhilePressedPort"/> gives hold-to-channel,
+/// <see cref="OnReleasedPort"/> with a timer gives a charged shot, and
+/// <paramref name="deactivateOnPressed"/> inside a timer's subgraph gives a combo window.</para>
+/// <para>The events are edges the node itself saw, so a button already held when the node activates is not a press:
+/// a combo window must not fire on a button nobody pressed inside it, and the button that started the ability is
+/// usually still down when the window opens. The subgraph is the other half of that rule - it follows the button's
+/// state rather than its edges, so an ability activated by the very button it channels on starts channelling at once.
+/// </para>
+/// <para>Input is read straight from the device, which makes this client-local. An authoritative or networked game
+/// should sample button state once at activation into the ability's activation data rather than polling it inside a
+/// graph the server runs.</para>
+/// </remarks>
+/// <param name="actionName">The input action to watch.</param>
+/// <param name="deactivateOnPressed">Whether the node deactivates itself on the first press, for the "wait for one
+/// button and move on" shape.</param>
+[StatescriptCategory("Input")]
+public class InputActionNode(string actionName = "", bool deactivateOnPressed = false)
+	: StateNode<InputActionNodeContext>
+{
+	/// <summary>
+	/// Output port index for the event emitted when the button goes down.
+	/// </summary>
+	public const byte OnPressedPort = 4;
+
+	/// <summary>
+	/// Output port index for the event emitted when the button comes up.
+	/// </summary>
+	public const byte OnReleasedPort = 5;
+
+	/// <summary>
+	/// Output port index for the subgraph that is active while the button is down.
+	/// </summary>
+	public const byte WhilePressedPort = 6;
+
+	private readonly string _actionName = actionName ?? string.Empty;
+	private readonly bool _deactivateOnPressed = deactivateOnPressed;
+
+	private bool _reportedMissingAction;
+
+	/// <inheritdoc/>
+	public override string Description =>
+		"Watches a button while active, emitting press and release events and routing a held subgraph.";
+
+	/// <inheritdoc/>
+	protected override void DefinePorts(List<InputPort> inputPorts, List<OutputPort> outputPorts)
+	{
+		base.DefinePorts(inputPorts, outputPorts);
+		outputPorts.Add(CreatePort<EventPort>(OnPressedPort, "OnPressed"));
+		outputPorts.Add(CreatePort<EventPort>(OnReleasedPort, "OnReleased"));
+		outputPorts.Add(CreatePort<SubgraphPort>(WhilePressedPort, "WhilePressed"));
+	}
+
+	/// <inheritdoc/>
+	protected override void OnActivate(GraphContext graphContext)
+	{
+		graphContext.GetNodeContext<InputActionNodeContext>(NodeID).LastPressed = null;
+		Poll(graphContext);
+	}
+
+	/// <inheritdoc/>
+	protected override void OnDeactivate(GraphContext graphContext)
+	{
+		graphContext.GetNodeContext<InputActionNodeContext>(NodeID).LastPressed = null;
+	}
+
+	/// <inheritdoc/>
+	protected override void OnUpdate(double deltaTime, GraphContext graphContext)
+	{
+		Poll(graphContext);
+	}
+
+	private void Poll(GraphContext graphContext)
+	{
+		if (!InputMap.HasAction(_actionName))
+		{
+			ReportMissingActionOnce();
+			return;
+		}
+
+		InputActionNodeContext nodeContext = graphContext.GetNodeContext<InputActionNodeContext>(NodeID);
+		bool pressed = Input.IsActionPressed(_actionName);
+
+		if (nodeContext.LastPressed == pressed)
+		{
+			return;
+		}
+
+		bool hadValue = nodeContext.LastPressed.HasValue;
+		nodeContext.LastPressed = pressed;
+
+		if (!hadValue)
+		{
+			// The first read is the state the node started in rather than a change, so only the subgraph follows it.
+			if (pressed)
+			{
+				EmitMessage(graphContext, WhilePressedPort);
+			}
+
+			return;
+		}
+
+		if (!pressed)
+		{
+			var whilePressedPort = (SubgraphPort)OutputPorts[WhilePressedPort];
+			whilePressedPort.EmitDisableSubgraphMessage(graphContext);
+			EmitMessage(graphContext, OnReleasedPort);
+			return;
+		}
+
+		if (_deactivateOnPressed)
+		{
+			DeactivateNodeAndEmitMessage(graphContext, OnPressedPort);
+			return;
+		}
+
+		EmitMessage(graphContext, OnPressedPort, WhilePressedPort);
+	}
+
+	// Godot pushes an error of its own for every read of an action that does not exist, which on a node polling each
+	// frame is an error per frame.
+	private void ReportMissingActionOnce()
+	{
+		if (_reportedMissingAction)
+		{
+			return;
+		}
+
+		_reportedMissingAction = true;
+
+		GD.PushWarning(
+			$"Statescript: Input Action names the input action [{_actionName}], which the project's Input Map does " +
+			"not have. Nothing is being watched.");
+	}
+}

--- a/addons/forge/core/statescript/nodes/state/InputActionNode.cs.uid
+++ b/addons/forge/core/statescript/nodes/state/InputActionNode.cs.uid
@@ -1,0 +1,1 @@
+uid://cesjxwtdfvrww

--- a/addons/forge/core/statescript/nodes/state/InputActionNodeContext.cs
+++ b/addons/forge/core/statescript/nodes/state/InputActionNodeContext.cs
@@ -1,0 +1,18 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Statescript.Nodes;
+
+namespace Gamesmiths.Forge.Godot.Core.Statescript.Nodes.State;
+
+/// <summary>
+/// The context for an <see cref="InputActionNode"/>. Remembers whether the button was down, which is what turns a
+/// per-tick read into the presses and releases the node reports.
+/// </summary>
+public class InputActionNodeContext : StateNodeContext
+{
+	/// <summary>
+	/// Gets or sets whether the button was down on the last read. Null before the first one, which is what keeps a
+	/// button already held when the node activated from counting as a press.
+	/// </summary>
+	public bool? LastPressed { get; set; }
+}

--- a/addons/forge/core/statescript/nodes/state/InputActionNodeContext.cs.uid
+++ b/addons/forge/core/statescript/nodes/state/InputActionNodeContext.cs.uid
@@ -1,0 +1,1 @@
+uid://4hchho0sm72t

--- a/addons/forge/core/statescript/resolvers/CameraForward3DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/CameraForward3DResolver.cs
@@ -1,0 +1,26 @@
+// Copyright © Gamesmiths Guild.
+
+using System;
+using Gamesmiths.Forge.Statescript;
+using Godot;
+using NumericsVector3 = System.Numerics.Vector3;
+
+namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+
+/// <summary>
+/// Resolves the direction the camera a graph is looking through faces, as a unit vector.
+/// </summary>
+/// <remarks>
+/// Unpaired: a 2D camera has no forward. Godot's forward is −Z, which this already accounts for, so a ray cast along it
+/// goes where the crosshair points rather than behind the player.
+/// </remarks>
+internal sealed class CameraForward3DResolver : CameraResolverBase3D
+{
+	public override Type ValueType => typeof(NumericsVector3);
+
+	protected override Variant128 ResolveFrom(Node3D contextNode, Camera3D camera, GraphContext graphContext)
+	{
+		Vector3 forward = -camera.GlobalBasis.Z.Normalized();
+		return new Variant128(new NumericsVector3(forward.X, forward.Y, forward.Z));
+	}
+}

--- a/addons/forge/core/statescript/resolvers/CameraForward3DResolver.cs.uid
+++ b/addons/forge/core/statescript/resolvers/CameraForward3DResolver.cs.uid
@@ -1,0 +1,1 @@
+uid://x4vo3yqb537o

--- a/addons/forge/core/statescript/resolvers/CameraPosition3DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/CameraPosition3DResolver.cs
@@ -1,0 +1,26 @@
+// Copyright © Gamesmiths Guild.
+
+using System;
+using Gamesmiths.Forge.Statescript;
+using Godot;
+using NumericsVector3 = System.Numerics.Vector3;
+
+namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+
+/// <summary>
+/// Resolves where the camera a graph is looking through sits in the world.
+/// </summary>
+/// <remarks>
+/// Paired with Camera Forward 3D this is the origin and direction of a shooter's centre-aim ray, which is the reason
+/// both exist: a hitscan shot is aimed from the eye, not from the muzzle, or it disagrees with the crosshair.
+/// </remarks>
+internal sealed class CameraPosition3DResolver : CameraResolverBase3D
+{
+	public override Type ValueType => typeof(NumericsVector3);
+
+	protected override Variant128 ResolveFrom(Node3D contextNode, Camera3D camera, GraphContext graphContext)
+	{
+		Vector3 position = camera.GlobalPosition;
+		return new Variant128(new NumericsVector3(position.X, position.Y, position.Z));
+	}
+}

--- a/addons/forge/core/statescript/resolvers/CameraPosition3DResolver.cs.uid
+++ b/addons/forge/core/statescript/resolvers/CameraPosition3DResolver.cs.uid
@@ -1,0 +1,1 @@
+uid://cf8v7m13xj27t

--- a/addons/forge/core/statescript/resolvers/CameraResolverBase3D.cs
+++ b/addons/forge/core/statescript/resolvers/CameraResolverBase3D.cs
@@ -1,0 +1,74 @@
+// Copyright © Gamesmiths Guild.
+
+using System;
+using Gamesmiths.Forge.Godot.Core.Statescript.Physics;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+
+/// <summary>
+/// Base for every resolver that reads through the 3D camera a graph is looking through.
+/// </summary>
+/// <remarks>
+/// <para>Which camera that is comes from the ability's owner, not from the main scene tree: the active camera of the
+/// viewport the owner is standing in. A split-screen game runs one graph per player and each reads its own half, and a
+/// world rendered inside a sub-viewport is aimed through the camera that renders it rather than through whatever the
+/// main window holds.</para>
+/// <para>These are deliberately not prefixed <c>Entity</c> and take no entity operand. A camera is not something an
+/// entity has - it is how the graph's own player sees, which is a property of the ability being run.</para>
+/// </remarks>
+internal abstract class CameraResolverBase3D : IPropertyResolver
+{
+	private bool _reportedMissingCamera;
+
+	/// <inheritdoc/>
+	public abstract Type ValueType { get; }
+
+	/// <summary>
+	/// Reads this resolver's value through the resolved camera.
+	/// </summary>
+	/// <param name="contextNode">The owner's spatial node, for resolvers that also need where the graph is standing.
+	/// </param>
+	/// <param name="camera">The active camera of the owner's viewport.</param>
+	/// <param name="graphContext">The running graph context, for subclasses with operands of their own to resolve.
+	/// </param>
+	/// <returns>The resolved value.</returns>
+	protected abstract Variant128 ResolveFrom(Node3D contextNode, Camera3D camera, GraphContext graphContext);
+
+#pragma warning disable SA1202 // Elements should be ordered by access
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		if (!PhysicsQuery3D.TryResolveContextNode(graphContext, out Node3D? contextNode))
+		{
+			ReportMissingCameraOnce("has no owner in the scene to read a viewport from");
+			return default;
+		}
+
+		Camera3D? camera = contextNode.GetViewport()?.GetCamera3D();
+
+		if (camera is null)
+		{
+			ReportMissingCameraOnce("found no active camera in its owner's viewport");
+			return default;
+		}
+
+		return ResolveFrom(contextNode, camera, graphContext);
+	}
+#pragma warning restore SA1202 // Elements should be ordered by access
+
+	// Resolvers run every tick, so a warning left unsuppressed would repeat every frame.
+	private void ReportMissingCameraOnce(string message)
+	{
+		if (_reportedMissingCamera)
+		{
+			return;
+		}
+
+		_reportedMissingCamera = true;
+
+		GD.PushWarning($"Statescript: {GetType().Name} {message}. Resolving to a default value.");
+	}
+}

--- a/addons/forge/core/statescript/resolvers/CameraResolverBase3D.cs.uid
+++ b/addons/forge/core/statescript/resolvers/CameraResolverBase3D.cs.uid
@@ -1,0 +1,1 @@
+uid://hyiacc5241ba

--- a/addons/forge/core/statescript/resolvers/InputActionMode.cs
+++ b/addons/forge/core/statescript/resolvers/InputActionMode.cs
@@ -1,0 +1,25 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+
+/// <summary>
+/// Which question the input action resolver asks about a button.
+/// </summary>
+public enum InputActionMode
+{
+	/// <summary>
+	/// Whether the button is down right now. This is the one a condition wants: it reads the same on every frame the
+	/// button is held.
+	/// </summary>
+	Pressed = 0,
+
+	/// <summary>
+	/// Whether the button went down this frame.
+	/// </summary>
+	JustPressed = 1,
+
+	/// <summary>
+	/// Whether the button came up this frame.
+	/// </summary>
+	JustReleased = 2,
+}

--- a/addons/forge/core/statescript/resolvers/InputActionMode.cs.uid
+++ b/addons/forge/core/statescript/resolvers/InputActionMode.cs.uid
@@ -1,0 +1,1 @@
+uid://cfoct8g0ecmv2

--- a/addons/forge/core/statescript/resolvers/InputActionPressedResolver.cs
+++ b/addons/forge/core/statescript/resolvers/InputActionPressedResolver.cs
@@ -19,7 +19,7 @@ namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
 internal sealed class InputActionPressedResolver(string actionName, InputActionMode mode)
 	: InputResolverBase(actionName)
 {
-	private readonly string _actionName = actionName;
+	private readonly StringName _actionName = actionName;
 	private readonly InputActionMode _mode = mode;
 
 	public override Type ValueType => typeof(bool);

--- a/addons/forge/core/statescript/resolvers/InputActionPressedResolver.cs
+++ b/addons/forge/core/statescript/resolvers/InputActionPressedResolver.cs
@@ -1,0 +1,36 @@
+// Copyright © Gamesmiths Guild.
+
+using System;
+using Gamesmiths.Forge.Statescript;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+
+/// <summary>
+/// Resolves whether an input action is down, went down this frame, or came up this frame.
+/// </summary>
+/// <remarks>
+/// This is the composable half of Input Action: a bool an Expression or a Condition Monitor can gate on, where the node
+/// is what a graph waits on. Reading it inside a subgraph that already runs every frame is the usual reason to reach
+/// for it.
+/// </remarks>
+/// <param name="actionName">The input action to read.</param>
+/// <param name="mode">Which question to ask about the button.</param>
+internal sealed class InputActionPressedResolver(string actionName, InputActionMode mode)
+	: InputResolverBase(actionName)
+{
+	private readonly string _actionName = actionName;
+	private readonly InputActionMode _mode = mode;
+
+	public override Type ValueType => typeof(bool);
+
+	protected override Variant128 ResolveInput()
+	{
+		return new Variant128(_mode switch
+		{
+			InputActionMode.JustPressed => Input.IsActionJustPressed(_actionName),
+			InputActionMode.JustReleased => Input.IsActionJustReleased(_actionName),
+			_ => Input.IsActionPressed(_actionName),
+		});
+	}
+}

--- a/addons/forge/core/statescript/resolvers/InputActionPressedResolver.cs.uid
+++ b/addons/forge/core/statescript/resolvers/InputActionPressedResolver.cs.uid
@@ -1,0 +1,1 @@
+uid://dqmpv51vs83pu

--- a/addons/forge/core/statescript/resolvers/InputActionStrengthResolver.cs
+++ b/addons/forge/core/statescript/resolvers/InputActionStrengthResolver.cs
@@ -1,0 +1,27 @@
+// Copyright © Gamesmiths Guild.
+
+using System;
+using Gamesmiths.Forge.Statescript;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+
+/// <summary>
+/// Resolves how far an input action is pressed, from 0 to 1.
+/// </summary>
+/// <remarks>
+/// A digital button reads 0 or 1, so this is the analog form of Input Action Pressed: an analog trigger scaling a
+/// shot's magnitude, a stick pushed part way scaling a movement speed.
+/// </remarks>
+/// <param name="actionName">The input action to read.</param>
+internal sealed class InputActionStrengthResolver(string actionName) : InputResolverBase(actionName)
+{
+	private readonly string _actionName = actionName;
+
+	public override Type ValueType => typeof(float);
+
+	protected override Variant128 ResolveInput()
+	{
+		return new Variant128(Input.GetActionStrength(_actionName));
+	}
+}

--- a/addons/forge/core/statescript/resolvers/InputActionStrengthResolver.cs
+++ b/addons/forge/core/statescript/resolvers/InputActionStrengthResolver.cs
@@ -16,7 +16,7 @@ namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
 /// <param name="actionName">The input action to read.</param>
 internal sealed class InputActionStrengthResolver(string actionName) : InputResolverBase(actionName)
 {
-	private readonly string _actionName = actionName;
+	private readonly StringName _actionName = actionName;
 
 	public override Type ValueType => typeof(float);
 

--- a/addons/forge/core/statescript/resolvers/InputActionStrengthResolver.cs.uid
+++ b/addons/forge/core/statescript/resolvers/InputActionStrengthResolver.cs.uid
@@ -1,0 +1,1 @@
+uid://cfemj5oxulg11

--- a/addons/forge/core/statescript/resolvers/InputAxisResolver.cs
+++ b/addons/forge/core/statescript/resolvers/InputAxisResolver.cs
@@ -1,0 +1,30 @@
+// Copyright © Gamesmiths Guild.
+
+using System;
+using Gamesmiths.Forge.Statescript;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+
+/// <summary>
+/// Resolves the signed strength of a pair of opposed input actions, from −1 to 1.
+/// </summary>
+/// <remarks>
+/// The two actions cancel, so holding both reads zero rather than whichever was pressed last. That is the difference
+/// from subtracting two Input Action Strength resolvers, which is also why the pair earns a resolver of its own.
+/// </remarks>
+/// <param name="negativeAction">The action driving the value towards −1.</param>
+/// <param name="positiveAction">The action driving the value towards 1.</param>
+internal sealed class InputAxisResolver(string negativeAction, string positiveAction)
+	: InputResolverBase(negativeAction, positiveAction)
+{
+	private readonly string _negativeAction = negativeAction;
+	private readonly string _positiveAction = positiveAction;
+
+	public override Type ValueType => typeof(float);
+
+	protected override Variant128 ResolveInput()
+	{
+		return new Variant128(Input.GetAxis(_negativeAction, _positiveAction));
+	}
+}

--- a/addons/forge/core/statescript/resolvers/InputAxisResolver.cs
+++ b/addons/forge/core/statescript/resolvers/InputAxisResolver.cs
@@ -18,8 +18,8 @@ namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
 internal sealed class InputAxisResolver(string negativeAction, string positiveAction)
 	: InputResolverBase(negativeAction, positiveAction)
 {
-	private readonly string _negativeAction = negativeAction;
-	private readonly string _positiveAction = positiveAction;
+	private readonly StringName _negativeAction = negativeAction;
+	private readonly StringName _positiveAction = positiveAction;
 
 	public override Type ValueType => typeof(float);
 

--- a/addons/forge/core/statescript/resolvers/InputAxisResolver.cs.uid
+++ b/addons/forge/core/statescript/resolvers/InputAxisResolver.cs.uid
@@ -1,0 +1,1 @@
+uid://0x43erf23xta

--- a/addons/forge/core/statescript/resolvers/InputResolverBase.cs
+++ b/addons/forge/core/statescript/resolvers/InputResolverBase.cs
@@ -21,7 +21,7 @@ namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
 /// <param name="actionNames">The actions this resolver reads. All of them must exist for it to resolve.</param>
 internal abstract class InputResolverBase(params string[] actionNames) : IPropertyResolver
 {
-	private readonly string[] _actionNames = actionNames;
+	private readonly StringName[] _actionNames = Array.ConvertAll(actionNames, actionName => (StringName)actionName);
 
 	private bool _reportedMissingAction;
 
@@ -38,7 +38,7 @@ internal abstract class InputResolverBase(params string[] actionNames) : IProper
 	/// <inheritdoc/>
 	public Variant128 Resolve(GraphContext graphContext)
 	{
-		foreach (string actionName in _actionNames)
+		foreach (StringName actionName in _actionNames)
 		{
 			if (!InputMap.HasAction(actionName))
 			{
@@ -51,7 +51,7 @@ internal abstract class InputResolverBase(params string[] actionNames) : IProper
 	}
 #pragma warning restore SA1202 // Elements should be ordered by access
 
-	private void ReportMissingActionOnce(string actionName)
+	private void ReportMissingActionOnce(StringName actionName)
 	{
 		if (_reportedMissingAction)
 		{

--- a/addons/forge/core/statescript/resolvers/InputResolverBase.cs
+++ b/addons/forge/core/statescript/resolvers/InputResolverBase.cs
@@ -1,0 +1,67 @@
+// Copyright © Gamesmiths Guild.
+
+using System;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+
+/// <summary>
+/// Base for every resolver that reads the state of one or more input actions.
+/// </summary>
+/// <remarks>
+/// <para>Handles the one thing all of them share: an action name is authored as free text, so it can name an action the
+/// project's <c>InputMap</c> does not have. Godot pushes an error of its own for every such read, which on a resolver
+/// running each tick is an error per frame, so the names are checked first and reported once.</para>
+/// <para>Input is read straight from the device, which makes these client-local. An authoritative or networked game
+/// should sample aim and button state once at activation into the ability's activation data rather than polling them
+/// inside a graph the server runs.</para>
+/// </remarks>
+/// <param name="actionNames">The actions this resolver reads. All of them must exist for it to resolve.</param>
+internal abstract class InputResolverBase(params string[] actionNames) : IPropertyResolver
+{
+	private readonly string[] _actionNames = actionNames;
+
+	private bool _reportedMissingAction;
+
+	/// <inheritdoc/>
+	public abstract Type ValueType { get; }
+
+	/// <summary>
+	/// Reads this resolver's value off the device. Called only once every action it names exists.
+	/// </summary>
+	/// <returns>The resolved value.</returns>
+	protected abstract Variant128 ResolveInput();
+
+#pragma warning disable SA1202 // Elements should be ordered by access
+	/// <inheritdoc/>
+	public Variant128 Resolve(GraphContext graphContext)
+	{
+		foreach (string actionName in _actionNames)
+		{
+			if (!InputMap.HasAction(actionName))
+			{
+				ReportMissingActionOnce(actionName);
+				return default;
+			}
+		}
+
+		return ResolveInput();
+	}
+#pragma warning restore SA1202 // Elements should be ordered by access
+
+	private void ReportMissingActionOnce(string actionName)
+	{
+		if (_reportedMissingAction)
+		{
+			return;
+		}
+
+		_reportedMissingAction = true;
+
+		GD.PushWarning(
+			$"Statescript: {GetType().Name} names the input action [{actionName}], which the project's Input Map " +
+			"does not have. Resolving to a default value.");
+	}
+}

--- a/addons/forge/core/statescript/resolvers/InputResolverBase.cs.uid
+++ b/addons/forge/core/statescript/resolvers/InputResolverBase.cs.uid
@@ -1,0 +1,1 @@
+uid://byxjw20ympuxj

--- a/addons/forge/core/statescript/resolvers/InputVector2Resolver.cs
+++ b/addons/forge/core/statescript/resolvers/InputVector2Resolver.cs
@@ -1,0 +1,41 @@
+// Copyright © Gamesmiths Guild.
+
+using System;
+using Gamesmiths.Forge.Statescript;
+using Godot;
+using NumericsVector2 = System.Numerics.Vector2;
+
+namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+
+/// <summary>
+/// Resolves the direction four opposed input actions point in, as a vector no longer than 1.
+/// </summary>
+/// <remarks>
+/// This is aiming without a camera: the stick or the movement keys are the aim, which is what a twin-stick shooter and
+/// a keyboard-steered dash both want. Godot clamps the result to the unit circle, so a diagonal is not faster than a
+/// straight line, and screen axes apply - up is −Y.
+/// </remarks>
+/// <param name="negativeXAction">The action pointing left.</param>
+/// <param name="positiveXAction">The action pointing right.</param>
+/// <param name="negativeYAction">The action pointing up.</param>
+/// <param name="positiveYAction">The action pointing down.</param>
+internal sealed class InputVector2Resolver(
+	string negativeXAction,
+	string positiveXAction,
+	string negativeYAction,
+	string positiveYAction)
+	: InputResolverBase(negativeXAction, positiveXAction, negativeYAction, positiveYAction)
+{
+	private readonly string _negativeXAction = negativeXAction;
+	private readonly string _positiveXAction = positiveXAction;
+	private readonly string _negativeYAction = negativeYAction;
+	private readonly string _positiveYAction = positiveYAction;
+
+	public override Type ValueType => typeof(NumericsVector2);
+
+	protected override Variant128 ResolveInput()
+	{
+		Vector2 vector = Input.GetVector(_negativeXAction, _positiveXAction, _negativeYAction, _positiveYAction);
+		return new Variant128(new NumericsVector2(vector.X, vector.Y));
+	}
+}

--- a/addons/forge/core/statescript/resolvers/InputVector2Resolver.cs
+++ b/addons/forge/core/statescript/resolvers/InputVector2Resolver.cs
@@ -26,10 +26,10 @@ internal sealed class InputVector2Resolver(
 	string positiveYAction)
 	: InputResolverBase(negativeXAction, positiveXAction, negativeYAction, positiveYAction)
 {
-	private readonly string _negativeXAction = negativeXAction;
-	private readonly string _positiveXAction = positiveXAction;
-	private readonly string _negativeYAction = negativeYAction;
-	private readonly string _positiveYAction = positiveYAction;
+	private readonly StringName _negativeXAction = negativeXAction;
+	private readonly StringName _positiveXAction = positiveXAction;
+	private readonly StringName _negativeYAction = negativeYAction;
+	private readonly StringName _positiveYAction = positiveYAction;
 
 	public override Type ValueType => typeof(NumericsVector2);
 

--- a/addons/forge/core/statescript/resolvers/InputVector2Resolver.cs.uid
+++ b/addons/forge/core/statescript/resolvers/InputVector2Resolver.cs.uid
@@ -1,0 +1,1 @@
+uid://birfb0vqjkdp6

--- a/addons/forge/core/statescript/resolvers/MouseWorldMode.cs
+++ b/addons/forge/core/statescript/resolvers/MouseWorldMode.cs
@@ -1,0 +1,22 @@
+// Copyright © Gamesmiths Guild.
+
+namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+
+/// <summary>
+/// How the mouse cursor is turned into a point in the world.
+/// </summary>
+public enum MouseWorldMode
+{
+	/// <summary>
+	/// Cast the cursor's ray into physics and take what it hits. This follows the terrain, so a cursor over a hill
+	/// resolves onto the hill, and it is what a game whose ground is not flat wants.
+	/// </summary>
+	PhysicsRay = 0,
+
+	/// <summary>
+	/// Intersect the cursor's ray with the horizontal plane the caster is standing on. Nothing between the camera and
+	/// the ground can block it, so a cursor over a wall, a tree or another character still resolves to the ground under
+	/// it - which is what a top-down game usually means by "where the player clicked".
+	/// </summary>
+	PlaneIntersect = 1,
+}

--- a/addons/forge/core/statescript/resolvers/MouseWorldMode.cs.uid
+++ b/addons/forge/core/statescript/resolvers/MouseWorldMode.cs.uid
@@ -1,0 +1,1 @@
+uid://ddw4wpme5tfes

--- a/addons/forge/core/statescript/resolvers/MouseWorldPosition3DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/MouseWorldPosition3DResolver.cs
@@ -1,0 +1,107 @@
+// Copyright © Gamesmiths Guild.
+
+using System;
+using Gamesmiths.Forge.Godot.Core.Statescript.Physics;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Godot;
+using NumericsVector3 = System.Numerics.Vector3;
+
+namespace Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+
+/// <summary>
+/// Resolves the point in the world the mouse cursor is over.
+/// </summary>
+/// <remarks>
+/// <para>This is the cursor-aimed half of the standard aim payload, for the graphs that want to keep reading it rather
+/// than sample it once at activation: a ground-targeted area that follows the cursor while it is being placed, a turret
+/// that tracks it. An ability that only needs where the player was aiming when it started should read the payload
+/// instead, which is also what a networked game must do - the cursor lives on the client.</para>
+/// <para>Both modes end at the far end of the ray when they resolve to nothing, so a cursor pointed at empty sky still
+/// yields a usable point in the direction it was pointing rather than the world origin.</para>
+/// </remarks>
+/// <param name="mode">How the cursor's ray is turned into a point.</param>
+/// <param name="maskResolver">Resolves the physics layers the ray can hit under
+/// <see cref="MouseWorldMode.PhysicsRay"/>. Zero means every layer.</param>
+/// <param name="maxDistanceResolver">Resolves how far the ray reaches.</param>
+internal sealed class MouseWorldPosition3DResolver(
+	MouseWorldMode mode,
+	IPropertyResolver? maskResolver,
+	IPropertyResolver maxDistanceResolver) : CameraResolverBase3D
+{
+	private readonly MouseWorldMode _mode = mode;
+	private readonly IPropertyResolver? _maskResolver = maskResolver;
+	private readonly IPropertyResolver _maxDistanceResolver = maxDistanceResolver;
+
+	public override Type ValueType => typeof(NumericsVector3);
+
+	protected override Variant128 ResolveFrom(Node3D contextNode, Camera3D camera, GraphContext graphContext)
+	{
+		Viewport? viewport = camera.GetViewport();
+
+		if (viewport is null)
+		{
+			return default;
+		}
+
+		Vector2 mousePosition = viewport.GetMousePosition();
+		Vector3 rayOrigin = camera.ProjectRayOrigin(mousePosition);
+		Vector3 rayDirection = camera.ProjectRayNormal(mousePosition);
+		float maxDistance = (float)_maxDistanceResolver.Resolve(graphContext).AsDouble();
+		Vector3 rayEnd = rayOrigin + (rayDirection * maxDistance);
+
+		Vector3 point = _mode == MouseWorldMode.PlaneIntersect
+			? ResolveOnPlane(contextNode, rayOrigin, rayDirection, maxDistance, rayEnd)
+			: ResolveAgainstPhysics(contextNode, rayOrigin, rayDirection, maxDistance, graphContext, rayEnd);
+
+		return new Variant128(new NumericsVector3(point.X, point.Y, point.Z));
+	}
+
+	// The plane is infinite, so a near-horizontal ray meets it arbitrarily far away. Accepting that would silently
+	// ignore the max distance, so a point out of reach is discarded in favour of the ray's own end, which is clamped.
+	private static Vector3 ResolveOnPlane(
+		Node3D contextNode,
+		Vector3 rayOrigin,
+		Vector3 rayDirection,
+		float maxDistance,
+		Vector3 rayEnd)
+	{
+		Vector3? planePoint =
+			new Plane(Vector3.Up, contextNode.GlobalPosition.Y).IntersectsRay(rayOrigin, rayDirection);
+
+		return planePoint.HasValue && planePoint.Value.DistanceSquaredTo(rayOrigin) <= maxDistance * maxDistance
+			? planePoint.Value
+			: rayEnd;
+	}
+
+	private Vector3 ResolveAgainstPhysics(
+		Node3D contextNode,
+		Vector3 rayOrigin,
+		Vector3 rayDirection,
+		float maxDistance,
+		GraphContext graphContext,
+		Vector3 rayEnd)
+	{
+		World3D? world = contextNode.GetWorld3D();
+
+		if (world is null)
+		{
+			return rayEnd;
+		}
+
+		int mask = _maskResolver is null ? 0 : (int)_maskResolver.Resolve(graphContext).AsDouble();
+
+		return PhysicsQuery3D.TryRaycast(
+			world,
+			rayOrigin,
+			rayDirection,
+			maxDistance,
+			PhysicsQuery3D.ResolveMask(mask),
+			collideWithAreas: false,
+			hitFromInside: false,
+			exclude: null,
+			out RaycastResult3D result)
+				? result.Position
+				: rayEnd;
+	}
+}

--- a/addons/forge/core/statescript/resolvers/MouseWorldPosition3DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/MouseWorldPosition3DResolver.cs
@@ -47,7 +47,8 @@ internal sealed class MouseWorldPosition3DResolver(
 		Vector2 mousePosition = viewport.GetMousePosition();
 		Vector3 rayOrigin = camera.ProjectRayOrigin(mousePosition);
 		Vector3 rayDirection = camera.ProjectRayNormal(mousePosition);
-		float maxDistance = (float)_maxDistanceResolver.Resolve(graphContext).AsDouble();
+
+		float maxDistance = (float)Math.Max(_maxDistanceResolver.Resolve(graphContext).AsDouble(), 0.0);
 		Vector3 rayEnd = rayOrigin + (rayDirection * maxDistance);
 
 		Vector3 point = _mode == MouseWorldMode.PlaneIntersect

--- a/addons/forge/core/statescript/resolvers/MouseWorldPosition3DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/MouseWorldPosition3DResolver.cs
@@ -37,14 +37,7 @@ internal sealed class MouseWorldPosition3DResolver(
 
 	protected override Variant128 ResolveFrom(Node3D contextNode, Camera3D camera, GraphContext graphContext)
 	{
-		Viewport? viewport = camera.GetViewport();
-
-		if (viewport is null)
-		{
-			return default;
-		}
-
-		Vector2 mousePosition = viewport.GetMousePosition();
+		Vector2 mousePosition = camera.GetViewport().GetMousePosition();
 		Vector3 rayOrigin = camera.ProjectRayOrigin(mousePosition);
 		Vector3 rayDirection = camera.ProjectRayNormal(mousePosition);
 

--- a/addons/forge/core/statescript/resolvers/MouseWorldPosition3DResolver.cs.uid
+++ b/addons/forge/core/statescript/resolvers/MouseWorldPosition3DResolver.cs.uid
@@ -1,0 +1,1 @@
+uid://ju41w63uks7t

--- a/addons/forge/editor/SearchableOptionButton.cs
+++ b/addons/forge/editor/SearchableOptionButton.cs
@@ -7,31 +7,18 @@ namespace Gamesmiths.Forge.Godot.Editor;
 
 /// <summary>
 /// A drop-in <see cref="OptionButton"/> that turns on Godot's popup search bar (4.7+) so long pickers, such as the
-/// resolver list on a numeric input, can be filtered by typing. The bar only appears once the list reaches
-/// <see cref="MinItemCountForSearch"/> items, so short dropdowns look and behave exactly like a plain
-/// <see cref="OptionButton"/>.
+/// resolver list on a numeric input, can be filtered by typing. The bar only appears once the list is long enough, so
+/// short dropdowns look and behave exactly like a plain <see cref="OptionButton"/>.
 /// </summary>
 [Tool]
 internal sealed partial class SearchableOptionButton : OptionButton
 {
-	// Lists shorter than this keep the plain dropdown (no search bar), mirroring Godot's own threshold behavior.
-	private const int MinItemCountForSearch = 10;
-
-	private const int MaxPopupHeight = 400;
-
 	/// <inheritdoc/>
 	public override void _Ready()
 	{
 		base._Ready();
 
-		PopupMenu popup = GetPopup();
-		popup.SearchBarEnabled = true;
-		popup.SearchBarMinItemCount = MinItemCountForSearch;
-
-		Rect2I usableScreen = DisplayServer.ScreenGetUsableRect(GetWindow().CurrentScreen);
-		popup.MaxSize = new Vector2I(
-			usableScreen.Size.X,
-			(int)(MaxPopupHeight * EditorInterface.Singleton.GetEditorScale()));
+		SearchablePopup.Configure(GetPopup(), GetWindow());
 	}
 }
 #endif

--- a/addons/forge/editor/SearchablePopup.cs
+++ b/addons/forge/editor/SearchablePopup.cs
@@ -1,0 +1,39 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Editor;
+
+/// <summary>
+/// Turns on Godot's popup search bar (4.7+) and caps a popup's height, so a long list can be filtered by typing
+/// instead of running off the screen.
+/// </summary>
+/// <remarks>
+/// Shared so every long picker in the plugin behaves the same way, whether it hangs off an
+/// <see cref="OptionButton"/> or a <see cref="MenuButton"/>.
+/// </remarks>
+internal static class SearchablePopup
+{
+	// Lists shorter than this keep the plain dropdown (no search bar), mirroring Godot's own threshold behavior.
+	private const int MinItemCountForSearch = 10;
+
+	private const int MaxPopupHeight = 400;
+
+	/// <summary>
+	/// Applies the shared search bar and height cap to a popup.
+	/// </summary>
+	/// <param name="popup">The popup to configure.</param>
+	/// <param name="window">The window the popup opens from, for the screen its height is capped against.</param>
+	public static void Configure(PopupMenu popup, Window window)
+	{
+		popup.SearchBarEnabled = true;
+		popup.SearchBarMinItemCount = MinItemCountForSearch;
+
+		Rect2I usableScreen = DisplayServer.ScreenGetUsableRect(window.CurrentScreen);
+		popup.MaxSize = new Vector2I(
+			usableScreen.Size.X,
+			(int)(MaxPopupHeight * EditorInterface.Singleton.GetEditorScale()));
+	}
+}
+#endif

--- a/addons/forge/editor/SearchablePopup.cs.uid
+++ b/addons/forge/editor/SearchablePopup.cs.uid
@@ -1,0 +1,1 @@
+uid://dfl8vinj1mk37

--- a/addons/forge/editor/statescript/InputActionNameField.cs
+++ b/addons/forge/editor/statescript/InputActionNameField.cs
@@ -1,0 +1,215 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using System;
+using System.Collections.Generic;
+using Godot;
+using GodotDictionary = Godot.Collections.Dictionary;
+
+namespace Gamesmiths.Forge.Godot.Editor.Statescript;
+
+/// <summary>
+/// A text field for an input action name with a dropdown offering the project's own actions.
+/// </summary>
+/// <remarks>
+/// <para>Action names are free text because the action map belongs to the game and is reached through an engine-generic
+/// mechanism, exactly as animation names are. Typing one from memory is still how most of them get misspelled, so the
+/// project's actions are offered beside the field - a picker for the ones that exist, free text for the ones the
+/// project does not define yet.</para>
+/// <para>The field stays editable rather than becoming a plain dropdown because the project's action list is a
+/// <em>subset</em> of what the runtime accepts: Godot's <c>ui_*</c> presets are valid and deliberately not listed, and
+/// a game may register actions from code that no project setting knows about. A dropdown would also have to decide what
+/// to show once an action is renamed away under a graph that still names it, and both answers are wrong - the node
+/// settings row would display the first action while the node runs the stored one, and a resolver editor would rewrite
+/// the stored name on the next save. A name that is kept and flagged beats a name silently replaced.</para>
+/// <para>The same control serves node settings and resolver editors, so an action is authored the same way wherever it
+/// appears. It wraps a field the caller built and bound, rather than owning one, because the two callers persist a
+/// change differently: a node setting records an undo step against its <c>CustomData</c>, while a resolver writes
+/// through its editor's save callback.</para>
+/// </remarks>
+[Tool]
+internal sealed partial class InputActionNameField : HBoxContainer
+{
+	/// <summary>
+	/// The project setting every input action is stored under.
+	/// </summary>
+	private const string ActionSettingPrefix = "input/";
+
+	/// <summary>
+	/// The prefix Godot's own preset actions carry. They are left out of the dropdown: every project has all hundred
+	/// of them, none is what a gameplay graph is watching, and listing them buries the ones that are. They are still
+	/// accepted when typed, which is one of the reasons the field stays free text.
+	/// </summary>
+	private const string PresetActionPrefix = "ui_";
+
+	private const float DropdownWidth = 24.0f;
+
+	/// <summary>
+	/// Names the project defines, cached so validating a keystroke does not walk every project setting.
+	/// </summary>
+	/// <remarks>
+	/// Refreshed when the row is built and whenever the dropdown opens, which are the moments an author can have
+	/// changed the action map since it was last read.
+	/// </remarks>
+	private readonly HashSet<string> _knownActions = new(StringComparer.Ordinal);
+
+	private LineEdit? _field;
+	private PopupMenu? _popup;
+	private Action? _onPicked;
+	private string _baseTooltip = string.Empty;
+
+	/// <summary>
+	/// Builds the row around an already-configured text field.
+	/// </summary>
+	/// <param name="field">The field holding the action name. Reparented into this control.</param>
+	/// <param name="onPicked">Called after the dropdown writes a name into the field. Setting the text in code raises
+	/// no change signal of its own, so this is what tells the caller to persist it.</param>
+	public void Initialize(LineEdit field, Action onPicked)
+	{
+		_field = field;
+		_onPicked = onPicked;
+		_baseTooltip = field.TooltipText;
+
+		SizeFlagsHorizontal = SizeFlags.ExpandFill;
+		AddThemeConstantOverride("separation", 2);
+		AddChild(field);
+
+		field.TextChanged += _ => UpdateValidationCue();
+
+		var dropdown = new MenuButton
+		{
+			Text = "▾",
+			CustomMinimumSize = new Vector2(DropdownWidth, 0),
+			TooltipText = "Pick one of the project's input actions.",
+		};
+
+		_popup = dropdown.GetPopup();
+		dropdown.AboutToPopup += PopulateActions;
+		_popup.IndexPressed += OnActionPicked;
+
+		AddChild(dropdown);
+
+		RefreshKnownActions();
+		UpdateValidationCue();
+	}
+
+	/// <inheritdoc cref="NodeEditorProperty.ClearCallbacks"/>
+	public void ClearCallbacks()
+	{
+		_field = null;
+		_popup = null;
+		_onPicked = null;
+	}
+
+	private static IEnumerable<string> EnumerateActionNames()
+	{
+		foreach (GodotDictionary property in ProjectSettings.Singleton.GetPropertyList())
+		{
+			string settingName = property["name"].AsString();
+
+			if (!settingName.StartsWith(ActionSettingPrefix, StringComparison.Ordinal))
+			{
+				continue;
+			}
+
+			string actionName = settingName[ActionSettingPrefix.Length..];
+
+			// A feature override is stored as a second setting under the same action - "input/skill_1.macos" - and is
+			// not a name anything can be watched by. The action's own setting is always there beside it.
+			if (!actionName.Contains('.'))
+			{
+				yield return actionName;
+			}
+		}
+	}
+
+	// Read on every popup rather than once, so an action added to the project while the graph is open is offered
+	// without reopening it.
+	private void PopulateActions()
+	{
+		if (_popup is null || !IsInstanceValid(_popup))
+		{
+			return;
+		}
+
+		_popup.Clear();
+		RefreshKnownActions();
+
+		foreach (string actionName in EnumerateActionNames())
+		{
+			if (!actionName.StartsWith(PresetActionPrefix, StringComparison.Ordinal))
+			{
+				_popup.AddItem(actionName);
+			}
+		}
+
+		if (_popup.ItemCount == 0)
+		{
+			_popup.AddItem("(no actions in the project's Input Map)");
+			_popup.SetItemDisabled(0, true);
+		}
+
+		// Applied here rather than at construction because the popup has to be in the tree to know which screen to cap
+		// its height against, and a project with a lot of actions is exactly the case that needs both.
+		SearchablePopup.Configure(_popup, GetWindow());
+
+		// Opening the dropdown is also when a name typed before its action existed stops being unknown.
+		UpdateValidationCue();
+	}
+
+	private void RefreshKnownActions()
+	{
+		_knownActions.Clear();
+
+		foreach (string actionName in EnumerateActionNames())
+		{
+			_knownActions.Add(actionName);
+		}
+	}
+
+	// Marks a name the project does not define without touching it. The value is still what runs, because it may
+	// legitimately be a preset or an action the game registers from code - this says what is known, not what is wrong.
+	private void UpdateValidationCue()
+	{
+		if (_field is null || !IsInstanceValid(_field))
+		{
+			return;
+		}
+
+		string actionName = _field.Text;
+
+		// An empty field is a row nobody has filled in yet rather than a mistake, and its placeholder already says so.
+		if (actionName.Length == 0 || _knownActions.Contains(actionName))
+		{
+			_field.RemoveThemeColorOverride("font_color");
+			_field.TooltipText = _baseTooltip;
+			return;
+		}
+
+		Theme editorTheme = EditorInterface.Singleton.GetEditorTheme();
+
+		if (editorTheme.HasColor("warning_color", "Editor"))
+		{
+			_field.AddThemeColorOverride("font_color", editorTheme.GetColor("warning_color", "Editor"));
+		}
+
+		string warning = $"\"{actionName}\" is not an action this project defines.\n\n" +
+			"It still works if the game registers it at runtime, or if it is one of Godot's built-in ui_ actions;\n" +
+			"otherwise nothing is watched and the graph warns once when it runs.";
+
+		_field.TooltipText = _baseTooltip.Length > 0 ? $"{_baseTooltip}\n\n{warning}" : warning;
+	}
+
+	private void OnActionPicked(long index)
+	{
+		if (_field is null || !IsInstanceValid(_field) || _popup is null || !IsInstanceValid(_popup))
+		{
+			return;
+		}
+
+		_field.Text = _popup.GetItemText((int)index);
+		UpdateValidationCue();
+		_onPicked?.Invoke();
+	}
+}
+#endif

--- a/addons/forge/editor/statescript/InputActionNameField.cs.uid
+++ b/addons/forge/editor/statescript/InputActionNameField.cs.uid
@@ -1,0 +1,1 @@
+uid://cb4yq5khhnfvv

--- a/addons/forge/editor/statescript/node_editors/InputActionNodeEditor.cs
+++ b/addons/forge/editor/statescript/node_editors/InputActionNodeEditor.cs
@@ -1,0 +1,31 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using System.Collections.Generic;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Editor.Statescript.NodeEditors;
+
+/// <summary>
+/// Node editor for Input Action.
+/// </summary>
+[Tool]
+internal sealed partial class InputActionNodeEditor : StandardNodeEditorBase
+{
+	private static readonly IReadOnlyList<NodeConfigParam> _configParams =
+	[
+		new NodeConfigParam(
+			"actionName",
+			"Action",
+			IsText: true,
+			Placeholder: "action_name",
+			SuggestsInputActions: true),
+		new NodeConfigParam("deactivateOnPressed", "Deactivate On Pressed", DefaultBool: false),
+	];
+
+	public override string HandledRuntimeTypeName =>
+		"Gamesmiths.Forge.Godot.Core.Statescript.Nodes.State.InputActionNode";
+
+	protected override IReadOnlyList<NodeConfigParam> ConstructorParams => _configParams;
+}
+#endif

--- a/addons/forge/editor/statescript/node_editors/InputActionNodeEditor.cs.uid
+++ b/addons/forge/editor/statescript/node_editors/InputActionNodeEditor.cs.uid
@@ -1,0 +1,1 @@
+uid://yx3ph6brrr2s

--- a/addons/forge/editor/statescript/node_editors/NodeConfigParam.cs
+++ b/addons/forge/editor/statescript/node_editors/NodeConfigParam.cs
@@ -27,6 +27,8 @@ namespace Gamesmiths.Forge.Godot.Editor.Statescript.NodeEditors;
 /// for the names of things the graph cannot enumerate at authoring time - a node path into whichever scene the entity
 /// comes from, an animation name, an input action - which is why they are text rather than a picker.</param>
 /// <param name="Placeholder">The hint shown in an empty text field, ignored unless <see cref="IsText"/> is set.</param>
+/// <param name="SuggestsInputActions">When <see langword="true"/>, the text field is given a dropdown offering the
+/// project's input actions. Ignored unless <see cref="IsText"/> is set.</param>
 internal readonly record struct NodeConfigParam(
 	string Key,
 	string Label,
@@ -35,5 +37,6 @@ internal readonly record struct NodeConfigParam(
 	bool DefaultBool = false,
 	bool AffectsLayout = false,
 	bool IsText = false,
-	string Placeholder = "");
+	string Placeholder = "",
+	bool SuggestsInputActions = false);
 #endif

--- a/addons/forge/editor/statescript/node_editors/StandardNodeEditorBase.cs
+++ b/addons/forge/editor/statescript/node_editors/StandardNodeEditorBase.cs
@@ -1,6 +1,7 @@
 // Copyright © Gamesmiths Guild.
 
 #if TOOLS
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Gamesmiths.Forge.Godot.Resources.Statescript;
@@ -232,7 +233,9 @@ internal abstract partial class StandardNodeEditorBase : CustomNodeEditor
 	// typed - the field still owning focus is exactly when that happens. Those syncs record nothing, and the undo step
 	// is recorded once when the edit finishes, against the value the field held before it started. Without restoring
 	// that original first, the recording call would see no change from the keystroke syncs and register nothing at all.
-	private void BindTextRow(LineEdit lineEdit, NodeConfigParam parameter)
+	// The commit is handed back so a picker writing into the field in code can record the same step, which setting the
+	// text raises no signal for.
+	private Action BindTextRow(LineEdit lineEdit, NodeConfigParam parameter)
 	{
 		string originalValue = ReadStringConfig(parameter.Key, parameter.DefaultName ?? string.Empty);
 
@@ -256,6 +259,8 @@ internal abstract partial class StandardNodeEditorBase : CustomNodeEditor
 
 		lineEdit.TextSubmitted += _ => CommitEdit();
 		lineEdit.FocusExited += CommitEdit;
+
+		return CommitEdit;
 	}
 
 	private void AddParamRow(GridContainer grid, NodeConfigParam parameter)
@@ -271,9 +276,17 @@ internal abstract partial class StandardNodeEditorBase : CustomNodeEditor
 				SizeFlagsHorizontal = Control.SizeFlags.ExpandFill,
 			};
 
-			BindTextRow(lineEdit, parameter);
+			Action commitEdit = BindTextRow(lineEdit, parameter);
 
-			grid.AddChild(lineEdit);
+			if (!parameter.SuggestsInputActions)
+			{
+				grid.AddChild(lineEdit);
+				return;
+			}
+
+			var actionField = new InputActionNameField();
+			actionField.Initialize(lineEdit, commitEdit);
+			grid.AddChild(actionField);
 			return;
 		}
 
@@ -282,7 +295,7 @@ internal abstract partial class StandardNodeEditorBase : CustomNodeEditor
 			grid.AddChild(BuildSettingsLabel(parameter));
 
 			string currentName = ReadStringConfig(parameter.Key, parameter.DefaultName ?? enumNames[0]);
-			int currentIndex = System.Array.IndexOf(enumNames, currentName);
+			int currentIndex = Array.IndexOf(enumNames, currentName);
 
 			var dropdown = new OptionButton { SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
 			for (int i = 0; i < enumNames.Length; i++)

--- a/addons/forge/editor/statescript/resolvers/CameraForward3DResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/CameraForward3DResolverEditor.cs
@@ -1,0 +1,53 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using System;
+using Gamesmiths.Forge.Godot.Resources.Statescript;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+using Godot;
+using ForgeVariant128 = Gamesmiths.Forge.Statescript.Variant128;
+using NumericsVector3 = System.Numerics.Vector3;
+
+namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver editor that reads the direction the camera a graph is looking through faces.
+/// </summary>
+/// <remarks>
+/// No rows: which camera is decided by the graph's own owner, so there is nothing to author.
+/// </remarks>
+[Tool]
+internal sealed partial class CameraForward3DResolverEditor : NodeEditorProperty
+{
+	public override string DisplayName => "Camera Forward 3D";
+
+	public override string ResolverTypeId => "CameraForward3D";
+
+	public override bool IsCompatibleWith(Type expectedType)
+	{
+		return expectedType == typeof(NumericsVector3) || expectedType == typeof(ForgeVariant128);
+	}
+
+	public override void Setup(
+		StatescriptGraph graph,
+		StatescriptNodeProperty? property,
+		Type expectedType,
+		Action onChanged,
+		bool isArray)
+	{
+		SizeFlagsHorizontal = SizeFlags.ExpandFill;
+		AddChild(new Label { Text = "Uses the owner's active camera." });
+	}
+
+	public override void SaveTo(StatescriptNodeProperty property)
+	{
+		property.Resolver = new CameraForward3DResolverResource();
+	}
+
+	public override bool TryGetInlineSummary(out string summary)
+	{
+		summary = "Camera Forward 3D";
+		return true;
+	}
+}
+#endif

--- a/addons/forge/editor/statescript/resolvers/CameraForward3DResolverEditor.cs.uid
+++ b/addons/forge/editor/statescript/resolvers/CameraForward3DResolverEditor.cs.uid
@@ -1,0 +1,1 @@
+uid://byjcucuponj6i

--- a/addons/forge/editor/statescript/resolvers/CameraPosition3DResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/CameraPosition3DResolverEditor.cs
@@ -1,0 +1,53 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using System;
+using Gamesmiths.Forge.Godot.Resources.Statescript;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+using Godot;
+using ForgeVariant128 = Gamesmiths.Forge.Statescript.Variant128;
+using NumericsVector3 = System.Numerics.Vector3;
+
+namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver editor that reads where the camera a graph is looking through sits.
+/// </summary>
+/// <remarks>
+/// No rows: which camera is decided by the graph's own owner, so there is nothing to author.
+/// </remarks>
+[Tool]
+internal sealed partial class CameraPosition3DResolverEditor : NodeEditorProperty
+{
+	public override string DisplayName => "Camera Position 3D";
+
+	public override string ResolverTypeId => "CameraPosition3D";
+
+	public override bool IsCompatibleWith(Type expectedType)
+	{
+		return expectedType == typeof(NumericsVector3) || expectedType == typeof(ForgeVariant128);
+	}
+
+	public override void Setup(
+		StatescriptGraph graph,
+		StatescriptNodeProperty? property,
+		Type expectedType,
+		Action onChanged,
+		bool isArray)
+	{
+		SizeFlagsHorizontal = SizeFlags.ExpandFill;
+		AddChild(new Label { Text = "Uses the owner's active camera." });
+	}
+
+	public override void SaveTo(StatescriptNodeProperty property)
+	{
+		property.Resolver = new CameraPosition3DResolverResource();
+	}
+
+	public override bool TryGetInlineSummary(out string summary)
+	{
+		summary = "Camera Position 3D";
+		return true;
+	}
+}
+#endif

--- a/addons/forge/editor/statescript/resolvers/CameraPosition3DResolverEditor.cs.uid
+++ b/addons/forge/editor/statescript/resolvers/CameraPosition3DResolverEditor.cs.uid
@@ -1,0 +1,1 @@
+uid://bnjmvrbw4tdg4

--- a/addons/forge/editor/statescript/resolvers/InputActionPressedResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/InputActionPressedResolverEditor.cs
@@ -1,0 +1,65 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using System;
+using Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+using Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers.Bases;
+using Gamesmiths.Forge.Godot.Resources.Statescript;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+using Godot;
+using ForgeVariant128 = Gamesmiths.Forge.Statescript.Variant128;
+
+namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver editor that reads whether an input action is down.
+/// </summary>
+[Tool]
+internal sealed partial class InputActionPressedResolverEditor : InputResolverEditorBase
+{
+	private static readonly string[] _modeNames = ["Pressed", "Just Pressed", "Just Released"];
+
+	private LineEdit? _actionField;
+	private OptionButton? _modeDropdown;
+
+	public override string DisplayName => "Input Action Pressed";
+
+	public override string ResolverTypeId => "InputActionPressed";
+
+	public override bool IsCompatibleWith(Type expectedType)
+	{
+		return expectedType == typeof(bool) || expectedType == typeof(ForgeVariant128);
+	}
+
+	public override void SaveTo(StatescriptNodeProperty property)
+	{
+		property.Resolver = new InputActionPressedResolverResource
+		{
+			ActionName = ReadActionName(_actionField),
+			Mode = (InputActionMode)(_modeDropdown?.Selected ?? 0),
+		};
+	}
+
+	public override bool TryGetInlineSummary(out string summary)
+	{
+		string actionName = ReadActionName(_actionField);
+		summary = actionName.Length > 0 ? actionName : "(None)";
+		return true;
+	}
+
+	public override void ClearCallbacks()
+	{
+		base.ClearCallbacks();
+		_actionField = null;
+		_modeDropdown = null;
+	}
+
+	protected override void BuildRows(VBoxContainer root, StatescriptResolverResource? existingResolver)
+	{
+		var resource = existingResolver as InputActionPressedResolverResource;
+
+		_actionField = AddActionRow(root, "Action:", resource?.ActionName ?? string.Empty);
+		_modeDropdown = AddEnumRow(root, "Mode:", _modeNames, (int)(resource?.Mode ?? InputActionMode.Pressed));
+	}
+}
+#endif

--- a/addons/forge/editor/statescript/resolvers/InputActionPressedResolverEditor.cs.uid
+++ b/addons/forge/editor/statescript/resolvers/InputActionPressedResolverEditor.cs.uid
@@ -1,0 +1,1 @@
+uid://hoan1ne1kvur

--- a/addons/forge/editor/statescript/resolvers/InputActionStrengthResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/InputActionStrengthResolverEditor.cs
@@ -1,0 +1,60 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using System;
+using Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers.Bases;
+using Gamesmiths.Forge.Godot.Resources.Statescript;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+using Godot;
+using ForgeVariant128 = Gamesmiths.Forge.Statescript.Variant128;
+
+namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver editor that reads how far an input action is pressed.
+/// </summary>
+[Tool]
+internal sealed partial class InputActionStrengthResolverEditor : InputResolverEditorBase
+{
+	private LineEdit? _actionField;
+
+	public override string DisplayName => "Input Action Strength";
+
+	public override string ResolverTypeId => "InputActionStrength";
+
+	public override bool IsCompatibleWith(Type expectedType)
+	{
+		return expectedType == typeof(float)
+			|| expectedType == typeof(double)
+			|| expectedType == typeof(ForgeVariant128);
+	}
+
+	public override void SaveTo(StatescriptNodeProperty property)
+	{
+		property.Resolver = new InputActionStrengthResolverResource
+		{
+			ActionName = ReadActionName(_actionField),
+		};
+	}
+
+	public override bool TryGetInlineSummary(out string summary)
+	{
+		string actionName = ReadActionName(_actionField);
+		summary = actionName.Length > 0 ? actionName : "(None)";
+		return true;
+	}
+
+	public override void ClearCallbacks()
+	{
+		base.ClearCallbacks();
+		_actionField = null;
+	}
+
+	protected override void BuildRows(VBoxContainer root, StatescriptResolverResource? existingResolver)
+	{
+		var resource = existingResolver as InputActionStrengthResolverResource;
+
+		_actionField = AddActionRow(root, "Action:", resource?.ActionName ?? string.Empty);
+	}
+}
+#endif

--- a/addons/forge/editor/statescript/resolvers/InputActionStrengthResolverEditor.cs.uid
+++ b/addons/forge/editor/statescript/resolvers/InputActionStrengthResolverEditor.cs.uid
@@ -1,0 +1,1 @@
+uid://vs4vq0nel0vf

--- a/addons/forge/editor/statescript/resolvers/InputAxisResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/InputAxisResolverEditor.cs
@@ -1,0 +1,63 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using System;
+using Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers.Bases;
+using Gamesmiths.Forge.Godot.Resources.Statescript;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+using Godot;
+using ForgeVariant128 = Gamesmiths.Forge.Statescript.Variant128;
+
+namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver editor that reads the signed strength of a pair of opposed input actions.
+/// </summary>
+[Tool]
+internal sealed partial class InputAxisResolverEditor : InputResolverEditorBase
+{
+	private LineEdit? _negativeField;
+	private LineEdit? _positiveField;
+
+	public override string DisplayName => "Input Axis";
+
+	public override string ResolverTypeId => "InputAxis";
+
+	public override bool IsCompatibleWith(Type expectedType)
+	{
+		return expectedType == typeof(float)
+			|| expectedType == typeof(double)
+			|| expectedType == typeof(ForgeVariant128);
+	}
+
+	public override void SaveTo(StatescriptNodeProperty property)
+	{
+		property.Resolver = new InputAxisResolverResource
+		{
+			NegativeAction = ReadActionName(_negativeField),
+			PositiveAction = ReadActionName(_positiveField),
+		};
+	}
+
+	public override bool TryGetInlineSummary(out string summary)
+	{
+		summary = "Input Axis";
+		return true;
+	}
+
+	public override void ClearCallbacks()
+	{
+		base.ClearCallbacks();
+		_negativeField = null;
+		_positiveField = null;
+	}
+
+	protected override void BuildRows(VBoxContainer root, StatescriptResolverResource? existingResolver)
+	{
+		var resource = existingResolver as InputAxisResolverResource;
+
+		_negativeField = AddActionRow(root, "Negative:", resource?.NegativeAction ?? string.Empty);
+		_positiveField = AddActionRow(root, "Positive:", resource?.PositiveAction ?? string.Empty);
+	}
+}
+#endif

--- a/addons/forge/editor/statescript/resolvers/InputAxisResolverEditor.cs.uid
+++ b/addons/forge/editor/statescript/resolvers/InputAxisResolverEditor.cs.uid
@@ -1,0 +1,1 @@
+uid://bynxeic71dw1

--- a/addons/forge/editor/statescript/resolvers/InputVector2ResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/InputVector2ResolverEditor.cs
@@ -1,0 +1,70 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using System;
+using Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers.Bases;
+using Gamesmiths.Forge.Godot.Resources.Statescript;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+using Godot;
+using ForgeVariant128 = Gamesmiths.Forge.Statescript.Variant128;
+using NumericsVector2 = System.Numerics.Vector2;
+
+namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver editor that reads the direction four opposed input actions point in.
+/// </summary>
+[Tool]
+internal sealed partial class InputVector2ResolverEditor : InputResolverEditorBase
+{
+	private LineEdit? _leftField;
+	private LineEdit? _rightField;
+	private LineEdit? _upField;
+	private LineEdit? _downField;
+
+	public override string DisplayName => "Input Vector 2";
+
+	public override string ResolverTypeId => "InputVector2";
+
+	public override bool IsCompatibleWith(Type expectedType)
+	{
+		return expectedType == typeof(NumericsVector2) || expectedType == typeof(ForgeVariant128);
+	}
+
+	public override void SaveTo(StatescriptNodeProperty property)
+	{
+		property.Resolver = new InputVector2ResolverResource
+		{
+			LeftAction = ReadActionName(_leftField),
+			RightAction = ReadActionName(_rightField),
+			UpAction = ReadActionName(_upField),
+			DownAction = ReadActionName(_downField),
+		};
+	}
+
+	public override bool TryGetInlineSummary(out string summary)
+	{
+		summary = "Input Vector 2";
+		return true;
+	}
+
+	public override void ClearCallbacks()
+	{
+		base.ClearCallbacks();
+		_leftField = null;
+		_rightField = null;
+		_upField = null;
+		_downField = null;
+	}
+
+	protected override void BuildRows(VBoxContainer root, StatescriptResolverResource? existingResolver)
+	{
+		var resource = existingResolver as InputVector2ResolverResource;
+
+		_leftField = AddActionRow(root, "Left:", resource?.LeftAction ?? string.Empty);
+		_rightField = AddActionRow(root, "Right:", resource?.RightAction ?? string.Empty);
+		_upField = AddActionRow(root, "Up:", resource?.UpAction ?? string.Empty);
+		_downField = AddActionRow(root, "Down:", resource?.DownAction ?? string.Empty);
+	}
+}
+#endif

--- a/addons/forge/editor/statescript/resolvers/InputVector2ResolverEditor.cs.uid
+++ b/addons/forge/editor/statescript/resolvers/InputVector2ResolverEditor.cs.uid
@@ -1,0 +1,1 @@
+uid://cst3owjc8uf28

--- a/addons/forge/editor/statescript/resolvers/MouseWorldPosition3DResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/MouseWorldPosition3DResolverEditor.cs
@@ -18,7 +18,6 @@ namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers;
 [Tool]
 internal sealed partial class MouseWorldPosition3DResolverEditor : NodeEditorProperty
 {
-	private const float LabelWidth = 74.0f;
 	private const double DefaultMaxDistance = 1000.0;
 
 	private static readonly string[] _modeNames = ["Physics Ray", "Plane Intersect"];
@@ -53,16 +52,12 @@ internal sealed partial class MouseWorldPosition3DResolverEditor : NodeEditorPro
 		var root = new VBoxContainer { SizeFlagsHorizontal = SizeFlags.ExpandFill };
 		AddChild(root);
 
-		_modeDropdown = new OptionButton { SizeFlagsHorizontal = SizeFlags.ExpandFill };
-
-		foreach (string modeName in _modeNames)
-		{
-			_modeDropdown.AddItem(modeName);
-		}
-
-		_modeDropdown.Selected = (int)(resource?.Mode ?? MouseWorldMode.PhysicsRay);
-		_modeDropdown.ItemSelected += _ => OnModeSelected();
-		root.AddChild(ResolverEditorLayoutUtilities.CreateLabeledRow("Mode:", _modeDropdown, LabelWidth));
+		_modeDropdown = ResolverEditorLayoutUtilities.CreateEnumRow(
+			root,
+			"Mode:",
+			_modeNames,
+			(int)(resource?.Mode ?? MouseWorldMode.PhysicsRay),
+			OnModeSelected);
 
 		_maskPicker = AddPicker(
 			graph,

--- a/addons/forge/editor/statescript/resolvers/MouseWorldPosition3DResolverEditor.cs
+++ b/addons/forge/editor/statescript/resolvers/MouseWorldPosition3DResolverEditor.cs
@@ -1,0 +1,172 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using System;
+using Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+using Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers.Bases;
+using Gamesmiths.Forge.Godot.Resources.Statescript;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+using Godot;
+using ForgeVariant128 = Gamesmiths.Forge.Statescript.Variant128;
+using NumericsVector3 = System.Numerics.Vector3;
+
+namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver editor that reads the point in the world the mouse cursor is over.
+/// </summary>
+[Tool]
+internal sealed partial class MouseWorldPosition3DResolverEditor : NodeEditorProperty
+{
+	private const float LabelWidth = 74.0f;
+	private const double DefaultMaxDistance = 1000.0;
+
+	private static readonly string[] _modeNames = ["Physics Ray", "Plane Intersect"];
+	private static readonly Type[] _maskExpectedTypes = [typeof(int)];
+	private static readonly Type[] _maxDistanceExpectedTypes = [typeof(double)];
+
+	private Action? _onChanged;
+	private OptionButton? _modeDropdown;
+	private NestedResolverPicker? _maskPicker;
+	private NestedResolverPicker? _maxDistancePicker;
+
+	public override string DisplayName => "Mouse World Position 3D";
+
+	public override string ResolverTypeId => "MouseWorldPosition3D";
+
+	public override bool IsCompatibleWith(Type expectedType)
+	{
+		return expectedType == typeof(NumericsVector3) || expectedType == typeof(ForgeVariant128);
+	}
+
+	public override void Setup(
+		StatescriptGraph graph,
+		StatescriptNodeProperty? property,
+		Type expectedType,
+		Action onChanged,
+		bool isArray)
+	{
+		var resource = property?.Resolver as MouseWorldPosition3DResolverResource;
+		_onChanged = onChanged;
+
+		SizeFlagsHorizontal = SizeFlags.ExpandFill;
+		var root = new VBoxContainer { SizeFlagsHorizontal = SizeFlags.ExpandFill };
+		AddChild(root);
+
+		_modeDropdown = new OptionButton { SizeFlagsHorizontal = SizeFlags.ExpandFill };
+
+		foreach (string modeName in _modeNames)
+		{
+			_modeDropdown.AddItem(modeName);
+		}
+
+		_modeDropdown.Selected = (int)(resource?.Mode ?? MouseWorldMode.PhysicsRay);
+		_modeDropdown.ItemSelected += _ => OnModeSelected();
+		root.AddChild(ResolverEditorLayoutUtilities.CreateLabeledRow("Mode:", _modeDropdown, LabelWidth));
+
+		_maskPicker = AddPicker(
+			graph,
+			root,
+			"Mask:",
+			resource?.Mask,
+			_maskExpectedTypes,
+			resource?.MaskFolded ?? true);
+
+		// Seeded with the same constant the resource falls back to: a nested operand has no unbound state, so an
+		// untouched distance would be zero and every query would resolve onto the camera itself.
+		_maxDistancePicker = AddPicker(
+			graph,
+			root,
+			"Max Dist:",
+			resource?.MaxDistance ?? BuildDefaultMaxDistance(),
+			_maxDistanceExpectedTypes,
+			resource?.MaxDistanceFolded ?? true);
+
+		UpdateMaskVisibility();
+	}
+
+	public override void SaveTo(StatescriptNodeProperty property)
+	{
+		property.Resolver = new MouseWorldPosition3DResolverResource
+		{
+			Mode = (MouseWorldMode)(_modeDropdown?.Selected ?? 0),
+			Mask = _maskPicker?.BuildResource(),
+			MaskFolded = _maskPicker?.Folded ?? true,
+			MaxDistance = _maxDistancePicker?.BuildResource(),
+			MaxDistanceFolded = _maxDistancePicker?.Folded ?? true,
+		};
+	}
+
+	public override bool TryGetInlineSummary(out string summary)
+	{
+		summary = "Mouse World Position 3D";
+		return true;
+	}
+
+	public override void ClearCallbacks()
+	{
+		base.ClearCallbacks();
+		_onChanged = null;
+		_modeDropdown = null;
+		_maskPicker?.ClearCallbacks();
+		_maskPicker = null;
+		_maxDistancePicker?.ClearCallbacks();
+		_maxDistancePicker = null;
+	}
+
+	private static VariantResolverResource BuildDefaultMaxDistance()
+	{
+		return new VariantResolverResource
+		{
+			Value = DefaultMaxDistance,
+			ValueType = StatescriptVariableType.Double,
+		};
+	}
+
+	private NestedResolverPicker AddPicker(
+		StatescriptGraph graph,
+		VBoxContainer root,
+		string title,
+		StatescriptResolverResource? existing,
+		Type[] expectedTypes,
+		bool folded)
+	{
+		var picker = new NestedResolverPicker();
+		picker.Initialize(
+			graph,
+			existing,
+			title,
+			expectedTypes,
+			isArray: false,
+			folded,
+			NotifyChanged,
+			RaiseLayoutSizeChanged,
+			IterationScope);
+
+		root.AddChild(picker);
+		return picker;
+	}
+
+	private void OnModeSelected()
+	{
+		UpdateMaskVisibility();
+		NotifyChanged();
+		RaiseLayoutSizeChanged();
+	}
+
+	// Plane Intersect asks nothing of physics, so the mask is not merely unused there - it would be a row an author
+	// can fill in and have silently ignored.
+	private void UpdateMaskVisibility()
+	{
+		if (_maskPicker is not null && IsInstanceValid(_maskPicker))
+		{
+			_maskPicker.Visible = _modeDropdown?.Selected == (int)MouseWorldMode.PhysicsRay;
+		}
+	}
+
+	private void NotifyChanged()
+	{
+		_onChanged?.Invoke();
+	}
+}
+#endif

--- a/addons/forge/editor/statescript/resolvers/MouseWorldPosition3DResolverEditor.cs.uid
+++ b/addons/forge/editor/statescript/resolvers/MouseWorldPosition3DResolverEditor.cs.uid
@@ -1,0 +1,1 @@
+uid://dlwtjrds5jssl

--- a/addons/forge/editor/statescript/resolvers/bases/InputResolverEditorBase.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/InputResolverEditorBase.cs
@@ -1,0 +1,133 @@
+// Copyright © Gamesmiths Guild.
+
+#if TOOLS
+using System;
+using System.Collections.Generic;
+using Gamesmiths.Forge.Godot.Resources.Statescript;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers.Bases;
+
+/// <summary>
+/// Base editor for every resolver that reads input actions.
+/// </summary>
+/// <remarks>
+/// They differ only in how many actions they name - one for a button, two for an axis, four for a vector - so the base
+/// renders the rows and the subclass says which ones it wants and what to build from them.
+/// </remarks>
+internal abstract partial class InputResolverEditorBase : NodeEditorProperty
+{
+	private const float LabelWidth = 74.0f;
+
+	private readonly List<InputActionNameField> _actionFields = [];
+
+	private Action? _onChanged;
+
+	/// <summary>
+	/// Adds this resolver's rows. Called with the container everything goes into.
+	/// </summary>
+	/// <param name="root">The container to add rows to.</param>
+	/// <param name="existingResolver">The resource being edited, when one exists.</param>
+	protected abstract void BuildRows(VBoxContainer root, StatescriptResolverResource? existingResolver);
+
+#pragma warning disable SA1202 // Elements should be ordered by access
+	/// <inheritdoc/>
+	public override void Setup(
+		StatescriptGraph graph,
+		StatescriptNodeProperty? property,
+		Type expectedType,
+		Action onChanged,
+		bool isArray)
+	{
+		_onChanged = onChanged;
+
+		SizeFlagsHorizontal = SizeFlags.ExpandFill;
+		var root = new VBoxContainer { SizeFlagsHorizontal = SizeFlags.ExpandFill };
+		AddChild(root);
+
+		BuildRows(root, property?.Resolver);
+	}
+
+	/// <inheritdoc/>
+	public override void ClearCallbacks()
+	{
+		base.ClearCallbacks();
+		_onChanged = null;
+
+		foreach (InputActionNameField actionField in _actionFields)
+		{
+			actionField.ClearCallbacks();
+		}
+
+		_actionFields.Clear();
+	}
+#pragma warning restore SA1202 // Elements should be ordered by access
+
+	/// <summary>
+	/// Reads a field's text, tolerating a control freed by a hot reload.
+	/// </summary>
+	/// <param name="field">The field to read.</param>
+	/// <returns>The text, or an empty string when the field is gone.</returns>
+	protected static string ReadActionName(LineEdit? field)
+	{
+		return field is not null && IsInstanceValid(field) ? field.Text : string.Empty;
+	}
+
+	/// <summary>
+	/// Adds a labeled action-name row backed by the Input Map dropdown.
+	/// </summary>
+	/// <param name="root">The container to add the row to.</param>
+	/// <param name="label">The row label.</param>
+	/// <param name="actionName">The name to start on.</param>
+	/// <returns>The field, so the caller can read it when saving.</returns>
+	protected LineEdit AddActionRow(VBoxContainer root, string label, string actionName)
+	{
+		var field = new LineEdit
+		{
+			Text = actionName,
+			PlaceholderText = "action_name",
+			SizeFlagsHorizontal = SizeFlags.ExpandFill,
+			TooltipText = "An action from the project's Input Map.",
+		};
+		field.TextChanged += _ => NotifyChanged();
+
+		var actionField = new InputActionNameField();
+		actionField.Initialize(field, NotifyChanged);
+		_actionFields.Add(actionField);
+
+		root.AddChild(ResolverEditorLayoutUtilities.CreateLabeledRow(label, actionField, LabelWidth));
+		return field;
+	}
+
+	/// <summary>
+	/// Adds a labeled dropdown row for an enum setting.
+	/// </summary>
+	/// <param name="root">The container to add the row to.</param>
+	/// <param name="label">The row label.</param>
+	/// <param name="itemNames">The entries, in enum order.</param>
+	/// <param name="selectedIndex">The entry to start on.</param>
+	/// <returns>The dropdown, so the caller can read its selection when saving.</returns>
+	protected OptionButton AddEnumRow(VBoxContainer root, string label, string[] itemNames, int selectedIndex)
+	{
+		var dropdown = new OptionButton { SizeFlagsHorizontal = SizeFlags.ExpandFill };
+
+		foreach (string itemName in itemNames)
+		{
+			dropdown.AddItem(itemName);
+		}
+
+		dropdown.Selected = Math.Clamp(selectedIndex, 0, itemNames.Length - 1);
+		dropdown.ItemSelected += _ => NotifyChanged();
+		root.AddChild(ResolverEditorLayoutUtilities.CreateLabeledRow(label, dropdown, LabelWidth));
+		return dropdown;
+	}
+
+	/// <summary>
+	/// Runs the editor's change callback.
+	/// </summary>
+	protected void NotifyChanged()
+	{
+		_onChanged?.Invoke();
+	}
+}
+#endif

--- a/addons/forge/editor/statescript/resolvers/bases/InputResolverEditorBase.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/InputResolverEditorBase.cs
@@ -17,8 +17,6 @@ namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers.Bases;
 /// </remarks>
 internal abstract partial class InputResolverEditorBase : NodeEditorProperty
 {
-	private const float LabelWidth = 74.0f;
-
 	private readonly List<InputActionNameField> _actionFields = [];
 
 	private Action? _onChanged;
@@ -95,7 +93,10 @@ internal abstract partial class InputResolverEditorBase : NodeEditorProperty
 		actionField.Initialize(field, NotifyChanged);
 		_actionFields.Add(actionField);
 
-		root.AddChild(ResolverEditorLayoutUtilities.CreateLabeledRow(label, actionField, LabelWidth));
+		root.AddChild(ResolverEditorLayoutUtilities.CreateLabeledRow(
+			label,
+			actionField,
+			ResolverEditorLayoutUtilities.SettingLabelWidth));
 		return field;
 	}
 
@@ -109,17 +110,7 @@ internal abstract partial class InputResolverEditorBase : NodeEditorProperty
 	/// <returns>The dropdown, so the caller can read its selection when saving.</returns>
 	protected OptionButton AddEnumRow(VBoxContainer root, string label, string[] itemNames, int selectedIndex)
 	{
-		var dropdown = new OptionButton { SizeFlagsHorizontal = SizeFlags.ExpandFill };
-
-		foreach (string itemName in itemNames)
-		{
-			dropdown.AddItem(itemName);
-		}
-
-		dropdown.Selected = Math.Clamp(selectedIndex, 0, itemNames.Length - 1);
-		dropdown.ItemSelected += _ => NotifyChanged();
-		root.AddChild(ResolverEditorLayoutUtilities.CreateLabeledRow(label, dropdown, LabelWidth));
-		return dropdown;
+		return ResolverEditorLayoutUtilities.CreateEnumRow(root, label, itemNames, selectedIndex, NotifyChanged);
 	}
 
 	/// <summary>

--- a/addons/forge/editor/statescript/resolvers/bases/InputResolverEditorBase.cs.uid
+++ b/addons/forge/editor/statescript/resolvers/bases/InputResolverEditorBase.cs.uid
@@ -1,0 +1,1 @@
+uid://c80skkbcxtqgg

--- a/addons/forge/editor/statescript/resolvers/bases/ResolverEditorLayoutUtilities.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/ResolverEditorLayoutUtilities.cs
@@ -1,6 +1,7 @@
 // Copyright © Gamesmiths Guild.
 
 #if TOOLS
+using System;
 using System.Collections.Generic;
 using Godot;
 
@@ -8,6 +9,41 @@ namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers.Bases;
 
 internal static class ResolverEditorLayoutUtilities
 {
+	/// <summary>
+	/// The label column width a resolver editor's setting rows share, so rows from different resolvers stacked in one
+	/// node line their controls up at the same x.
+	/// </summary>
+	public const float SettingLabelWidth = 74.0f;
+
+	/// <summary>
+	/// Builds a labeled dropdown row for an enum setting and adds it to a container.
+	/// </summary>
+	/// <param name="root">The container to add the row to.</param>
+	/// <param name="label">The row label.</param>
+	/// <param name="itemNames">The entries, in enum order.</param>
+	/// <param name="selectedIndex">The entry to start on, clamped to the entries that exist.</param>
+	/// <param name="onChanged">Called when the selection changes.</param>
+	/// <returns>The dropdown, so the caller can read its selection when saving.</returns>
+	public static OptionButton CreateEnumRow(
+		VBoxContainer root,
+		string label,
+		string[] itemNames,
+		int selectedIndex,
+		Action onChanged)
+	{
+		var dropdown = new OptionButton { SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };
+
+		foreach (string itemName in itemNames)
+		{
+			dropdown.AddItem(itemName);
+		}
+
+		dropdown.Selected = Math.Clamp(selectedIndex, 0, itemNames.Length - 1);
+		dropdown.ItemSelected += _ => onChanged();
+		root.AddChild(CreateLabeledRow(label, dropdown, SettingLabelWidth));
+		return dropdown;
+	}
+
 	public static HBoxContainer CreateLabeledRow(string labelText, Control editor, float labelWidth)
 	{
 		var row = new HBoxContainer { SizeFlagsHorizontal = Control.SizeFlags.ExpandFill };

--- a/addons/forge/editor/statescript/resolvers/bases/SpatialResolverEditorBase3D.cs
+++ b/addons/forge/editor/statescript/resolvers/bases/SpatialResolverEditorBase3D.cs
@@ -17,8 +17,6 @@ namespace Gamesmiths.Forge.Godot.Editor.Statescript.Resolvers.Bases;
 /// </remarks>
 internal abstract partial class SpatialResolverEditorBase3D : EntityScopedResolverEditorBase
 {
-	private const float LabelWidth = 74.0f;
-
 	private LineEdit? _nodePathField;
 
 	/// <summary>
@@ -72,8 +70,13 @@ internal abstract partial class SpatialResolverEditorBase3D : EntityScopedResolv
 			SizeFlagsHorizontal = SizeFlags.ExpandFill,
 			TooltipText = "Optional. A child node to read instead of the entity's own, such as a %Muzzle marker.",
 		};
+
 		_nodePathField.TextChanged += _ => NotifyChanged();
-		root.AddChild(ResolverEditorLayoutUtilities.CreateLabeledRow("Node:", _nodePathField, LabelWidth));
+
+		root.AddChild(ResolverEditorLayoutUtilities.CreateLabeledRow(
+			"Node:",
+			_nodePathField,
+			ResolverEditorLayoutUtilities.SettingLabelWidth));
 	}
 
 	/// <inheritdoc/>
@@ -114,17 +117,7 @@ internal abstract partial class SpatialResolverEditorBase3D : EntityScopedResolv
 	/// <returns>The dropdown, so the caller can read its selection when saving.</returns>
 	protected OptionButton BuildEnumRow(VBoxContainer root, string label, string[] itemNames, int selectedIndex)
 	{
-		var dropdown = new OptionButton { SizeFlagsHorizontal = SizeFlags.ExpandFill };
-
-		foreach (string itemName in itemNames)
-		{
-			dropdown.AddItem(itemName);
-		}
-
-		dropdown.Selected = Math.Clamp(selectedIndex, 0, itemNames.Length - 1);
-		dropdown.ItemSelected += _ => NotifyChanged();
-		root.AddChild(ResolverEditorLayoutUtilities.CreateLabeledRow(label, dropdown, LabelWidth));
-		return dropdown;
+		return ResolverEditorLayoutUtilities.CreateEnumRow(root, label, itemNames, selectedIndex, NotifyChanged);
 	}
 }
 #endif

--- a/addons/forge/resources/statescript/resolvers/CameraForward3DResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/CameraForward3DResolverResource.cs
@@ -1,0 +1,29 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers.Bases;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver resource that reads the direction the camera a graph is looking through faces.
+/// </summary>
+[Tool]
+[GlobalClass]
+public partial class CameraForward3DResolverResource : ValueResolverResourceBase
+{
+	/// <inheritdoc/>
+	public override string ResolverTypeId => "CameraForward3D";
+
+	/// <inheritdoc/>
+	protected override string PropertyNamePrefix => "cameraforward3d";
+
+	/// <inheritdoc/>
+	protected override IPropertyResolver CreateResolver(Graph graph)
+	{
+		return new CameraForward3DResolver();
+	}
+}

--- a/addons/forge/resources/statescript/resolvers/CameraForward3DResolverResource.cs.uid
+++ b/addons/forge/resources/statescript/resolvers/CameraForward3DResolverResource.cs.uid
@@ -1,0 +1,1 @@
+uid://bb2g7lq1wfrd8

--- a/addons/forge/resources/statescript/resolvers/CameraPosition3DResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/CameraPosition3DResolverResource.cs
@@ -1,0 +1,29 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers.Bases;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver resource that reads where the camera a graph is looking through sits.
+/// </summary>
+[Tool]
+[GlobalClass]
+public partial class CameraPosition3DResolverResource : ValueResolverResourceBase
+{
+	/// <inheritdoc/>
+	public override string ResolverTypeId => "CameraPosition3D";
+
+	/// <inheritdoc/>
+	protected override string PropertyNamePrefix => "cameraposition3d";
+
+	/// <inheritdoc/>
+	protected override IPropertyResolver CreateResolver(Graph graph)
+	{
+		return new CameraPosition3DResolver();
+	}
+}

--- a/addons/forge/resources/statescript/resolvers/CameraPosition3DResolverResource.cs.uid
+++ b/addons/forge/resources/statescript/resolvers/CameraPosition3DResolverResource.cs.uid
@@ -1,0 +1,1 @@
+uid://jictdw8k5u3s

--- a/addons/forge/resources/statescript/resolvers/InputActionPressedResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/InputActionPressedResolverResource.cs
@@ -1,0 +1,45 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers.Bases;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver resource that reads whether an input action is down.
+/// </summary>
+[Tool]
+[GlobalClass]
+public partial class InputActionPressedResolverResource : ValueResolverResourceBase
+{
+	/// <inheritdoc/>
+	public override string ResolverTypeId => "InputActionPressed";
+
+	/// <summary>
+	/// Gets or sets the input action to read.
+	/// </summary>
+	/// <remarks>
+	/// A name rather than a picker, exactly as animation names are: the action map belongs to the game and is reached
+	/// through an engine-generic mechanism, which is what keeps input inside the engine layer's scope.
+	/// </remarks>
+	[Export]
+	public string ActionName { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Gets or sets which question to ask about the button.
+	/// </summary>
+	[Export]
+	public InputActionMode Mode { get; set; }
+
+	/// <inheritdoc/>
+	protected override string PropertyNamePrefix => "inputactionpressed";
+
+	/// <inheritdoc/>
+	protected override IPropertyResolver CreateResolver(Graph graph)
+	{
+		return new InputActionPressedResolver(ActionName, Mode);
+	}
+}

--- a/addons/forge/resources/statescript/resolvers/InputActionPressedResolverResource.cs.uid
+++ b/addons/forge/resources/statescript/resolvers/InputActionPressedResolverResource.cs.uid
@@ -1,0 +1,1 @@
+uid://bqcpw72ibay04

--- a/addons/forge/resources/statescript/resolvers/InputActionStrengthResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/InputActionStrengthResolverResource.cs
@@ -1,0 +1,35 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers.Bases;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver resource that reads how far an input action is pressed.
+/// </summary>
+[Tool]
+[GlobalClass]
+public partial class InputActionStrengthResolverResource : ValueResolverResourceBase
+{
+	/// <inheritdoc/>
+	public override string ResolverTypeId => "InputActionStrength";
+
+	/// <summary>
+	/// Gets or sets the input action to read.
+	/// </summary>
+	[Export]
+	public string ActionName { get; set; } = string.Empty;
+
+	/// <inheritdoc/>
+	protected override string PropertyNamePrefix => "inputactionstrength";
+
+	/// <inheritdoc/>
+	protected override IPropertyResolver CreateResolver(Graph graph)
+	{
+		return new InputActionStrengthResolver(ActionName);
+	}
+}

--- a/addons/forge/resources/statescript/resolvers/InputActionStrengthResolverResource.cs.uid
+++ b/addons/forge/resources/statescript/resolvers/InputActionStrengthResolverResource.cs.uid
@@ -1,0 +1,1 @@
+uid://5wb6g27kuqsr

--- a/addons/forge/resources/statescript/resolvers/InputAxisResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/InputAxisResolverResource.cs
@@ -1,0 +1,41 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers.Bases;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver resource that reads the signed strength of a pair of opposed input actions.
+/// </summary>
+[Tool]
+[GlobalClass]
+public partial class InputAxisResolverResource : ValueResolverResourceBase
+{
+	/// <inheritdoc/>
+	public override string ResolverTypeId => "InputAxis";
+
+	/// <summary>
+	/// Gets or sets the action driving the value towards −1.
+	/// </summary>
+	[Export]
+	public string NegativeAction { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Gets or sets the action driving the value towards 1.
+	/// </summary>
+	[Export]
+	public string PositiveAction { get; set; } = string.Empty;
+
+	/// <inheritdoc/>
+	protected override string PropertyNamePrefix => "inputaxis";
+
+	/// <inheritdoc/>
+	protected override IPropertyResolver CreateResolver(Graph graph)
+	{
+		return new InputAxisResolver(NegativeAction, PositiveAction);
+	}
+}

--- a/addons/forge/resources/statescript/resolvers/InputAxisResolverResource.cs.uid
+++ b/addons/forge/resources/statescript/resolvers/InputAxisResolverResource.cs.uid
@@ -1,0 +1,1 @@
+uid://dxc0nmkxqlgl7

--- a/addons/forge/resources/statescript/resolvers/InputVector2ResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/InputVector2ResolverResource.cs
@@ -1,0 +1,53 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers.Bases;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver resource that reads the direction four opposed input actions point in.
+/// </summary>
+[Tool]
+[GlobalClass]
+public partial class InputVector2ResolverResource : ValueResolverResourceBase
+{
+	/// <inheritdoc/>
+	public override string ResolverTypeId => "InputVector2";
+
+	/// <summary>
+	/// Gets or sets the action pointing left.
+	/// </summary>
+	[Export]
+	public string LeftAction { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Gets or sets the action pointing right.
+	/// </summary>
+	[Export]
+	public string RightAction { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Gets or sets the action pointing up. Screen axes apply, so this is the one driving Y towards −1.
+	/// </summary>
+	[Export]
+	public string UpAction { get; set; } = string.Empty;
+
+	/// <summary>
+	/// Gets or sets the action pointing down.
+	/// </summary>
+	[Export]
+	public string DownAction { get; set; } = string.Empty;
+
+	/// <inheritdoc/>
+	protected override string PropertyNamePrefix => "inputvector2";
+
+	/// <inheritdoc/>
+	protected override IPropertyResolver CreateResolver(Graph graph)
+	{
+		return new InputVector2Resolver(LeftAction, RightAction, UpAction, DownAction);
+	}
+}

--- a/addons/forge/resources/statescript/resolvers/InputVector2ResolverResource.cs.uid
+++ b/addons/forge/resources/statescript/resolvers/InputVector2ResolverResource.cs.uid
@@ -1,0 +1,1 @@
+uid://ck3ifgqrt3chv

--- a/addons/forge/resources/statescript/resolvers/MouseWorldPosition3DResolverResource.cs
+++ b/addons/forge/resources/statescript/resolvers/MouseWorldPosition3DResolverResource.cs
@@ -1,0 +1,70 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Godot.Core.Statescript.Resolvers;
+using Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers.Bases;
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Godot;
+
+namespace Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers;
+
+/// <summary>
+/// Resolver resource that reads the point in the world the mouse cursor is over.
+/// </summary>
+[Tool]
+[GlobalClass]
+public partial class MouseWorldPosition3DResolverResource : ValueResolverResourceBase
+{
+	/// <summary>
+	/// How far the cursor's ray reaches when nothing was authored, matching the aim payload's own default.
+	/// </summary>
+	private const double DefaultMaxDistance = 1000.0;
+
+	/// <inheritdoc/>
+	public override string ResolverTypeId => "MouseWorldPosition3D";
+
+	/// <summary>
+	/// Gets or sets how the cursor's ray is turned into a point.
+	/// </summary>
+	[Export]
+	public MouseWorldMode Mode { get; set; }
+
+	/// <summary>
+	/// Gets or sets the nested resolver providing the physics layers the ray can hit. Zero means every layer.
+	/// </summary>
+	[Export]
+	public StatescriptResolverResource? Mask { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether the mask section is folded in the editor.
+	/// </summary>
+	[Export]
+	public bool MaskFolded { get; set; } = true;
+
+	/// <summary>
+	/// Gets or sets the nested resolver providing how far the ray reaches.
+	/// </summary>
+	[Export]
+	public StatescriptResolverResource? MaxDistance { get; set; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether the max distance section is folded in the editor.
+	/// </summary>
+	[Export]
+	public bool MaxDistanceFolded { get; set; } = true;
+
+	/// <inheritdoc/>
+	protected override string PropertyNamePrefix => "mouseworldposition3d";
+
+	/// <inheritdoc/>
+	protected override IPropertyResolver CreateResolver(Graph graph)
+	{
+		// A nested operand has no unbound state, so an unauthored distance would be zero and every query would resolve
+		// onto the camera itself. The editor seeds the row with the same constant this falls back to.
+		IPropertyResolver maxDistanceResolver = MaxDistance is null
+			? new VariantResolver(new Variant128(DefaultMaxDistance), typeof(double))
+			: AdaptResolverForExpectedType(MaxDistance.BuildResolver(graph), typeof(double));
+
+		return new MouseWorldPosition3DResolver(Mode, Mask?.BuildResolver(graph), maxDistanceResolver);
+	}
+}

--- a/addons/forge/resources/statescript/resolvers/MouseWorldPosition3DResolverResource.cs.uid
+++ b/addons/forge/resources/statescript/resolvers/MouseWorldPosition3DResolverResource.cs.uid
@@ -1,0 +1,1 @@
+uid://c45jxub2mc1hi

--- a/addons/forge/resources/statescript/resolvers/bases/ValueResolverResourceBase.cs
+++ b/addons/forge/resources/statescript/resolvers/bases/ValueResolverResourceBase.cs
@@ -1,0 +1,49 @@
+// Copyright © Gamesmiths Guild.
+
+using Gamesmiths.Forge.Statescript;
+using Gamesmiths.Forge.Statescript.Properties;
+using Godot;
+using ForgeNode = Gamesmiths.Forge.Statescript.Node;
+
+namespace Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers.Bases;
+
+/// <summary>
+/// Base resource for a resolver that produces a value-lane value from its own settings.
+/// </summary>
+/// <remarks>
+/// The whole of such a resolver's binding is defining a property and pointing the input at it, which is identical for
+/// every one of them. A concrete resource is then only its exported settings and the one line that builds its runtime
+/// counterpart.
+/// </remarks>
+[Tool]
+public abstract partial class ValueResolverResourceBase : StatescriptResolverResource
+{
+	/// <summary>
+	/// Builds the runtime resolver.
+	/// </summary>
+	/// <param name="graph">The runtime graph being built, for resolvers with nested operands.</param>
+	/// <returns>The runtime resolver.</returns>
+	protected abstract IPropertyResolver CreateResolver(Graph graph);
+
+	/// <summary>
+	/// Gets the prefix used to name this resolver's generated graph property.
+	/// </summary>
+	protected abstract string PropertyNamePrefix { get; }
+
+	/// <inheritdoc/>
+	public override void BindInput(Graph graph, ForgeNode runtimeNode, string nodeId, byte index)
+	{
+		DefineAndBindInputProperty(
+			graph,
+			runtimeNode,
+			$"__{PropertyNamePrefix}_{nodeId}_{index}",
+			index,
+			BuildResolver(graph));
+	}
+
+	/// <inheritdoc/>
+	public override IPropertyResolver BuildResolver(Graph graph)
+	{
+		return CreateResolver(graph);
+	}
+}

--- a/addons/forge/resources/statescript/resolvers/bases/ValueResolverResourceBase.cs.uid
+++ b/addons/forge/resources/statescript/resolvers/bases/ValueResolverResourceBase.cs.uid
@@ -1,0 +1,1 @@
+uid://6mjgdynx7t5o


### PR DESCRIPTION
Ships the Input Action node, four input resolvers and three camera resolvers, so aim and button input are authorable without code.