### PR TITLE
Added debug view to outline the entities a physics query found.

### DIFF
--- a/addons/forge/core/ForgeSettings.cs
+++ b/addons/forge/core/ForgeSettings.cs
@@ -27,6 +27,24 @@ public static class ForgeSettings
 	public const string DefaultSourcePath = "res://forge_tags.tres";
 
 	/// <summary>
+	/// Setting deciding whether a physics query outlines the entities it found, on top of the query geometry itself.
+	/// </summary>
+	public const string HighlightQueryTargetsSetting = "forge/statescript/highlight_query_targets";
+
+	/// <summary>
+	/// Gets a value indicating whether a physics query outlines the entities it found.
+	/// </summary>
+	/// <remarks>
+	/// A developer preference rather than something a graph authors, which is why it is a project setting and not a
+	/// node row: the answer is the same for every query in the project, and a per-query checkbox would be twenty
+	/// settings to keep in step. It only ever narrows what Godot's own Visible Collision Shapes already turned on -
+	/// with that off nothing is drawn either way - so an outline is one switch away when a crowded scene makes the
+	/// query geometry hard to read, and the query's own colour still says whether it found anything.
+	/// </remarks>
+	public static bool HighlightQueryTargets =>
+		ProjectSettings.GetSetting(HighlightQueryTargetsSetting, true).AsBool();
+
+	/// <summary>
 	/// Gets the configured tag source references, each a <c>uid://</c> or <c>res://</c> string.
 	/// </summary>
 	/// <returns>The configured references, or an empty array if unset.</returns>
@@ -82,21 +100,38 @@ public static class ForgeSettings
 
 #if TOOLS
 	/// <summary>
-	/// Declares the setting so it shows up in Project Settings with a sensible editing widget.
+	/// Declares the settings so they show up in Project Settings with sensible editing widgets.
 	/// </summary>
 	/// <remarks>
-	/// The initial value is deliberately an empty array and no value is written here. ProjectSettings skips saving any
-	/// property whose value still equals its initial value, so declaring a non-empty default would keep the setting out
-	/// of project.godot entirely until it happened to diverge.
+	/// The initial values are deliberately what an unset project already behaves as, and no value is written here.
+	/// ProjectSettings skips saving any property whose value still equals its initial value, so declaring a different
+	/// default would keep the setting out of project.godot entirely until it happened to diverge - which is also why
+	/// nothing is saved from here: neither declaration can reach the file, and the tag source writes its own setting
+	/// when it creates one.
 	/// </remarks>
 	public static void EnsureRegistered()
 	{
-		bool declared = ProjectSettings.HasSetting(SourcesSetting);
+		bool sourcesMissing = !ProjectSettings.HasSetting(SourcesSetting);
+		bool highlightMissing = !ProjectSettings.HasSetting(HighlightQueryTargetsSetting);
 
-		if (!declared)
+		if (sourcesMissing)
 		{
 			ProjectSettings.SetSetting(SourcesSetting, Array.Empty<string>());
 		}
+
+		if (highlightMissing)
+		{
+			ProjectSettings.SetSetting(HighlightQueryTargetsSetting, true);
+		}
+
+		ProjectSettings.AddPropertyInfo(new GodotDictionary
+		{
+			{ "name", HighlightQueryTargetsSetting },
+			{ "type", (int)Variant.Type.Bool },
+		});
+
+		ProjectSettings.SetInitialValue(HighlightQueryTargetsSetting, true);
+		ProjectSettings.SetAsBasic(HighlightQueryTargetsSetting, true);
 
 		ProjectSettings.AddPropertyInfo(new GodotDictionary
 		{
@@ -108,13 +143,6 @@ public static class ForgeSettings
 
 		ProjectSettings.SetInitialValue(SourcesSetting, Array.Empty<string>());
 		ProjectSettings.SetAsBasic(SourcesSetting, true);
-
-		// Property info and initial values are editor-session state, not file content, so only an actual first-time
-		// declaration is worth rewriting project.godot for.
-		if (!declared)
-		{
-			ProjectSettings.Save();
-		}
 	}
 #endif
 }

--- a/addons/forge/core/statescript/nodes/condition/Raycast2DNode.cs
+++ b/addons/forge/core/statescript/nodes/condition/Raycast2DNode.cs
@@ -59,6 +59,8 @@ public sealed class Raycast2DNode(bool collideWithAreas = false, bool hitFromIns
 			segment.To,
 			hit ? PhysicsDebugDraw2D.RayHitColor : PhysicsDebugDraw2D.RayClearColor);
 
+		PhysicsDebugDraw2D.FlashTarget(graphContext, result.Entity, PhysicsDebugDraw2D.RayHitColor);
+
 		return hit;
 	}
 }

--- a/addons/forge/core/statescript/nodes/condition/Raycast3DNode.cs
+++ b/addons/forge/core/statescript/nodes/condition/Raycast3DNode.cs
@@ -59,6 +59,8 @@ public sealed class Raycast3DNode(bool collideWithAreas = false, bool hitFromIns
 			segment.To,
 			hit ? PhysicsDebugDraw3D.RayHitColor : PhysicsDebugDraw3D.RayClearColor);
 
+		PhysicsDebugDraw3D.FlashTarget(graphContext, result.Entity, PhysicsDebugDraw3D.RayHitColor);
+
 		return hit;
 	}
 }

--- a/addons/forge/core/statescript/nodes/condition/Shapecast2DNode.cs
+++ b/addons/forge/core/statescript/nodes/condition/Shapecast2DNode.cs
@@ -68,6 +68,8 @@ public sealed class Shapecast2DNode(bool collideWithAreas = false) : ConditionNo
 				hit ? PhysicsDebugDraw2D.RayHitColor : PhysicsDebugDraw2D.RayClearColor);
 		}
 
+		PhysicsDebugDraw2D.FlashTarget(graphContext, result.Entity, PhysicsDebugDraw2D.RayHitColor);
+
 		return hit;
 	}
 }

--- a/addons/forge/core/statescript/nodes/condition/Shapecast3DNode.cs
+++ b/addons/forge/core/statescript/nodes/condition/Shapecast3DNode.cs
@@ -68,6 +68,8 @@ public sealed class Shapecast3DNode(bool collideWithAreas = false) : ConditionNo
 				hit ? PhysicsDebugDraw3D.RayHitColor : PhysicsDebugDraw3D.RayClearColor);
 		}
 
+		PhysicsDebugDraw3D.FlashTarget(graphContext, result.Entity, PhysicsDebugDraw3D.RayHitColor);
+
 		return hit;
 	}
 }

--- a/addons/forge/core/statescript/nodes/state/LineOfSight2DNode.cs
+++ b/addons/forge/core/statescript/nodes/state/LineOfSight2DNode.cs
@@ -227,6 +227,10 @@ public class LineOfSight2DNode(bool deactivateOnBlocked = false)
 		bool hadValue = nodeContext.LastClear.HasValue;
 		nodeContext.LastClear = clear;
 
+		// On the transition only, and only what got in the way: the held line is redrawn every check, and a clear line
+		// has nobody to name.
+		PhysicsDebugDraw2D.FlashTarget(graphContext, blocker.Entity, PhysicsDebugDraw2D.SightBlockedColor);
+
 		if (!clear && _deactivateOnBlocked)
 		{
 			DeactivateNodeAndEmitMessage(graphContext, OnBlockedPort);

--- a/addons/forge/core/statescript/nodes/state/LineOfSight3DNode.cs
+++ b/addons/forge/core/statescript/nodes/state/LineOfSight3DNode.cs
@@ -228,6 +228,10 @@ public class LineOfSight3DNode(bool deactivateOnBlocked = false)
 		bool hadValue = nodeContext.LastClear.HasValue;
 		nodeContext.LastClear = clear;
 
+		// On the transition only, and only what got in the way: the held line is redrawn every check, and a clear line
+		// has nobody to name.
+		PhysicsDebugDraw3D.FlashTarget(graphContext, blocker.Entity, PhysicsDebugDraw3D.SightBlockedColor);
+
 		if (!clear && _deactivateOnBlocked)
 		{
 			DeactivateNodeAndEmitMessage(graphContext, OnBlockedPort);

--- a/addons/forge/core/statescript/nodes/state/Overlap2DNode.cs
+++ b/addons/forge/core/statescript/nodes/state/Overlap2DNode.cs
@@ -273,6 +273,10 @@ public class Overlap2DNode(
 			else
 			{
 				to.Add(changed);
+
+				// Once, as it enters. The watched volume is held for as long as the node is, and says nothing about who
+				// is inside it; an outline redrawn every poll would stack up rather than read as a highlight.
+				PhysicsDebugDraw2D.FlashTarget(graphContext, changed, PhysicsDebugDraw2D.OverlapFoundColor);
 			}
 
 			WriteEventEntity(graphContext, OutputVariables[EventEntityOutput], changed);

--- a/addons/forge/core/statescript/nodes/state/Overlap3DNode.cs
+++ b/addons/forge/core/statescript/nodes/state/Overlap3DNode.cs
@@ -274,6 +274,10 @@ public class Overlap3DNode(
 			else
 			{
 				to.Add(changed);
+
+				// Once, as it enters. The watched volume is held for as long as the node is, and says nothing about who
+				// is inside it; an outline redrawn every poll would stack up rather than read as a highlight.
+				PhysicsDebugDraw3D.FlashTarget(graphContext, changed, PhysicsDebugDraw3D.OverlapFoundColor);
 			}
 
 			WriteEventEntity(graphContext, OutputVariables[EventEntityOutput], changed);

--- a/addons/forge/core/statescript/nodes/state/Ray2DNode.cs
+++ b/addons/forge/core/statescript/nodes/state/Ray2DNode.cs
@@ -134,6 +134,10 @@ public class Ray2DNode(
 		bool hadValue = nodeContext.LastHit.HasValue;
 		nodeContext.LastHit = hit;
 
+		// On the transition only. The held geometry is redrawn every cast, and outlining the target every cast would
+		// stack a fresh outline on the last one until nothing about it read as a highlight.
+		PhysicsDebugDraw2D.FlashTarget(graphContext, result.Entity, PhysicsDebugDraw2D.RayHitColor);
+
 		if (hit && _oneShot)
 		{
 			DeactivateNodeAndEmitMessage(graphContext, OnHitPort);

--- a/addons/forge/core/statescript/nodes/state/Ray3DNode.cs
+++ b/addons/forge/core/statescript/nodes/state/Ray3DNode.cs
@@ -134,6 +134,10 @@ public class Ray3DNode(
 		bool hadValue = nodeContext.LastHit.HasValue;
 		nodeContext.LastHit = hit;
 
+		// On the transition only. The held geometry is redrawn every cast, and outlining the target every cast would
+		// stack a fresh outline on the last one until nothing about it read as a highlight.
+		PhysicsDebugDraw3D.FlashTarget(graphContext, result.Entity, PhysicsDebugDraw3D.RayHitColor);
+
 		if (hit && _oneShot)
 		{
 			DeactivateNodeAndEmitMessage(graphContext, OnHitPort);

--- a/addons/forge/core/statescript/nodes/state/Sweep2DNode.cs
+++ b/addons/forge/core/statescript/nodes/state/Sweep2DNode.cs
@@ -146,6 +146,10 @@ public class Sweep2DNode(bool collideWithAreas = false, bool oneShot = false) : 
 		bool hadValue = nodeContext.LastHit.HasValue;
 		nodeContext.LastHit = hit;
 
+		// On the transition only. The held geometry is redrawn every cast, and outlining the target every cast would
+		// stack a fresh outline on the last one until nothing about it read as a highlight.
+		PhysicsDebugDraw2D.FlashTarget(graphContext, result.Entity, PhysicsDebugDraw2D.RayHitColor);
+
 		if (hit && _oneShot)
 		{
 			DeactivateNodeAndEmitMessage(graphContext, OnHitPort);

--- a/addons/forge/core/statescript/nodes/state/Sweep3DNode.cs
+++ b/addons/forge/core/statescript/nodes/state/Sweep3DNode.cs
@@ -146,6 +146,10 @@ public class Sweep3DNode(bool collideWithAreas = false, bool oneShot = false) : 
 		bool hadValue = nodeContext.LastHit.HasValue;
 		nodeContext.LastHit = hit;
 
+		// On the transition only. The held geometry is redrawn every cast, and outlining the target every cast would
+		// stack a fresh outline on the last one until nothing about it read as a highlight.
+		PhysicsDebugDraw3D.FlashTarget(graphContext, result.Entity, PhysicsDebugDraw3D.RayHitColor);
+
 		if (hit && _oneShot)
 		{
 			DeactivateNodeAndEmitMessage(graphContext, OnHitPort);

--- a/addons/forge/core/statescript/physics/PhysicsDebugDraw2D.cs
+++ b/addons/forge/core/statescript/physics/PhysicsDebugDraw2D.cs
@@ -1,5 +1,7 @@
 // Copyright © Gamesmiths Guild.
 
+using System.Collections.Generic;
+using Gamesmiths.Forge.Core;
 using Gamesmiths.Forge.Statescript;
 using Godot;
 using Node = Godot.Node;
@@ -42,6 +44,15 @@ internal static class PhysicsDebugDraw2D
 	/// Gets a value indicating whether the running game was started with Visible Collision Shapes on.
 	/// </summary>
 	public static bool IsEnabled => Engine.GetMainLoop() is SceneTree { DebugCollisionsHint: true };
+
+	/// <summary>
+	/// Gets a value indicating whether the entities a query found are outlined on top of the query's own geometry.
+	/// </summary>
+	/// <remarks>
+	/// A second switch inside the first, because the two answer different questions: the query geometry says where the
+	/// question was asked, and the outlines say who answered it. The second is what a crowded scene has too much of.
+	/// </remarks>
+	public static bool HighlightsTargets => IsEnabled && ForgeSettings.HighlightQueryTargets;
 
 	/// <summary>
 	/// Gets the colour of an overlap query that found nothing.
@@ -365,6 +376,49 @@ internal static class PhysicsDebugDraw2D
 				FlashShape(graphContext, collisionObject.ShapeOwnerGetShape(ownerId, shapeId), ownerTransform, color);
 			}
 		}
+	}
+
+	/// <summary>
+	/// Outlines the entities a query found, where they are, for a moment.
+	/// </summary>
+	/// <remarks>
+	/// The query's own geometry says where it looked and its colour says whether it found anything; this says
+	/// <em>who</em>, which is the part a shape drawn over a crowd cannot. Entities with no collider of their own are
+	/// skipped rather than marked, since there is no outline to draw for one and a stand-in shape would report a
+	/// volume the query never tested.
+	/// </remarks>
+	/// <param name="graphContext">The graph execution context, used to find the viewport to draw in.</param>
+	/// <param name="entities">The entities the query answered with.</param>
+	/// <param name="color">The colour to outline them in, matching the query's own.</param>
+	public static void FlashTargets(GraphContext graphContext, IEnumerable<IForgeEntity> entities, Color color)
+	{
+		if (!HighlightsTargets)
+		{
+			return;
+		}
+
+		foreach (IForgeEntity entity in entities)
+		{
+			FlashTarget(graphContext, entity, color);
+		}
+	}
+
+	/// <summary>
+	/// Outlines one entity a query found, where it is, for a moment.
+	/// </summary>
+	/// <param name="graphContext">The graph execution context, used to find the viewport to draw in.</param>
+	/// <param name="entity">The entity the query answered with, or <see langword="null"/> for none.</param>
+	/// <param name="color">The colour to outline it in, matching the query's own.</param>
+	public static void FlashTarget(GraphContext graphContext, IForgeEntity? entity, Color color)
+	{
+		if (!HighlightsTargets
+			|| !ForgeEntityBridge.TryGetSpatialNode2D(entity, out Node2D? spatialNode)
+			|| spatialNode is not CollisionObject2D collider)
+		{
+			return;
+		}
+
+		FlashBody(graphContext, collider, collider.GlobalTransform, color);
 	}
 
 	/// <summary>

--- a/addons/forge/core/statescript/physics/PhysicsDebugDraw2D.cs
+++ b/addons/forge/core/statescript/physics/PhysicsDebugDraw2D.cs
@@ -411,14 +411,12 @@ internal static class PhysicsDebugDraw2D
 	/// <param name="color">The colour to outline it in, matching the query's own.</param>
 	public static void FlashTarget(GraphContext graphContext, IForgeEntity? entity, Color color)
 	{
-		if (!HighlightsTargets
-			|| !ForgeEntityBridge.TryGetSpatialNode2D(entity, out Node2D? spatialNode)
-			|| spatialNode is not CollisionObject2D collider)
+		if (!HighlightsTargets || !ForgeEntityBridge.TryGetSpatialNode2D(entity, out Node2D? spatialNode))
 		{
 			return;
 		}
 
-		FlashBody(graphContext, collider, collider.GlobalTransform, color);
+		FlashColliders(graphContext, spatialNode, color);
 	}
 
 	/// <summary>
@@ -529,6 +527,19 @@ internal static class PhysicsDebugDraw2D
 		PhysicsDebugMarker2D? marker = CreateMarker(graphContext, color);
 		SetCone(marker, origin, direction, range, halfAngle);
 		Flash(marker);
+	}
+
+	private static void FlashColliders(GraphContext graphContext, Node node, Color color)
+	{
+		if (node is CollisionObject2D collider)
+		{
+			FlashBody(graphContext, collider, collider.GlobalTransform, color);
+		}
+
+		foreach (Node child in node.GetChildren())
+		{
+			FlashColliders(graphContext, child, color);
+		}
 	}
 
 	private static PhysicsDebugMarker2D? CreateMarker(GraphContext graphContext, Color color)

--- a/addons/forge/core/statescript/physics/PhysicsDebugDraw3D.cs
+++ b/addons/forge/core/statescript/physics/PhysicsDebugDraw3D.cs
@@ -1,6 +1,7 @@
 // Copyright © Gamesmiths Guild.
 
 using System.Collections.Generic;
+using Gamesmiths.Forge.Core;
 using Gamesmiths.Forge.Statescript;
 using Godot;
 using Node = Godot.Node;
@@ -42,6 +43,15 @@ internal static class PhysicsDebugDraw3D
 	/// Gets a value indicating whether the running game was started with Visible Collision Shapes on.
 	/// </summary>
 	public static bool IsEnabled => Engine.GetMainLoop() is SceneTree { DebugCollisionsHint: true };
+
+	/// <summary>
+	/// Gets a value indicating whether the entities a query found are outlined on top of the query's own geometry.
+	/// </summary>
+	/// <remarks>
+	/// A second switch inside the first, because the two answer different questions: the query geometry says where the
+	/// question was asked, and the outlines say who answered it. The second is what a crowded scene has too much of.
+	/// </remarks>
+	public static bool HighlightsTargets => IsEnabled && ForgeSettings.HighlightQueryTargets;
 
 	/// <summary>
 	/// Gets the colour of an overlap query that found nothing.
@@ -407,6 +417,49 @@ internal static class PhysicsDebugDraw3D
 				FlashShape(graphContext, collisionObject.ShapeOwnerGetShape(ownerId, shapeId), ownerTransform, color);
 			}
 		}
+	}
+
+	/// <summary>
+	/// Outlines the entities a query found, where they are, for a moment.
+	/// </summary>
+	/// <remarks>
+	/// The query's own geometry says where it looked and its colour says whether it found anything; this says
+	/// <em>who</em>, which is the part a shape drawn over a crowd cannot. Entities with no collider of their own are
+	/// skipped rather than marked, since there is no outline to draw for one and a stand-in shape would report a
+	/// volume the query never tested.
+	/// </remarks>
+	/// <param name="graphContext">The graph execution context, used to find the viewport to draw in.</param>
+	/// <param name="entities">The entities the query answered with.</param>
+	/// <param name="color">The colour to outline them in, matching the query's own.</param>
+	public static void FlashTargets(GraphContext graphContext, IEnumerable<IForgeEntity> entities, Color color)
+	{
+		if (!HighlightsTargets)
+		{
+			return;
+		}
+
+		foreach (IForgeEntity entity in entities)
+		{
+			FlashTarget(graphContext, entity, color);
+		}
+	}
+
+	/// <summary>
+	/// Outlines one entity a query found, where it is, for a moment.
+	/// </summary>
+	/// <param name="graphContext">The graph execution context, used to find the viewport to draw in.</param>
+	/// <param name="entity">The entity the query answered with, or <see langword="null"/> for none.</param>
+	/// <param name="color">The colour to outline it in, matching the query's own.</param>
+	public static void FlashTarget(GraphContext graphContext, IForgeEntity? entity, Color color)
+	{
+		if (!HighlightsTargets
+			|| !ForgeEntityBridge.TryGetSpatialNode3D(entity, out Node3D? spatialNode)
+			|| spatialNode is not CollisionObject3D collider)
+		{
+			return;
+		}
+
+		FlashBody(graphContext, collider, collider.GlobalTransform, color);
 	}
 
 	/// <summary>

--- a/addons/forge/core/statescript/physics/PhysicsDebugDraw3D.cs
+++ b/addons/forge/core/statescript/physics/PhysicsDebugDraw3D.cs
@@ -452,14 +452,12 @@ internal static class PhysicsDebugDraw3D
 	/// <param name="color">The colour to outline it in, matching the query's own.</param>
 	public static void FlashTarget(GraphContext graphContext, IForgeEntity? entity, Color color)
 	{
-		if (!HighlightsTargets
-			|| !ForgeEntityBridge.TryGetSpatialNode3D(entity, out Node3D? spatialNode)
-			|| spatialNode is not CollisionObject3D collider)
+		if (!HighlightsTargets || !ForgeEntityBridge.TryGetSpatialNode3D(entity, out Node3D? spatialNode))
 		{
 			return;
 		}
 
-		FlashBody(graphContext, collider, collider.GlobalTransform, color);
+		FlashColliders(graphContext, spatialNode, color);
 	}
 
 	/// <summary>
@@ -570,6 +568,19 @@ internal static class PhysicsDebugDraw3D
 		MeshInstance3D? marker = CreateMarker(graphContext, color);
 		SetCone(marker, origin, direction, range, halfAngle);
 		Flash(marker);
+	}
+
+	private static void FlashColliders(GraphContext graphContext, Node node, Color color)
+	{
+		if (node is CollisionObject3D collider)
+		{
+			FlashBody(graphContext, collider, collider.GlobalTransform, color);
+		}
+
+		foreach (Node child in node.GetChildren())
+		{
+			FlashColliders(graphContext, child, color);
+		}
 	}
 
 	private static MeshInstance3D? CreateMarker(GraphContext graphContext, Color color)

--- a/addons/forge/core/statescript/resolvers/AreaOverlaps2DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/AreaOverlaps2DResolver.cs
@@ -54,6 +54,10 @@ internal sealed class AreaOverlaps2DResolver(
 		_found.Clear();
 		PhysicsQuery2D.CollectAreaOverlaps(area, _includeAreas, _ignoreResolver?.ResolveArray(graphContext), _found);
 
+		// The area itself stays undrawn - it is in the scene and Godot renders it already - but which entities are
+		// inside it is not something that wireframe says.
+		PhysicsDebugDraw2D.FlashTargets(graphContext, _found, PhysicsDebugDraw2D.OverlapFoundColor);
+
 		var resolved = new IForgeEntity[_found.Count];
 		_found.CopyTo(resolved);
 		return resolved;

--- a/addons/forge/core/statescript/resolvers/AreaOverlaps3DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/AreaOverlaps3DResolver.cs
@@ -54,6 +54,10 @@ internal sealed class AreaOverlaps3DResolver(
 		_found.Clear();
 		PhysicsQuery3D.CollectAreaOverlaps(area, _includeAreas, _ignoreResolver?.ResolveArray(graphContext), _found);
 
+		// The area itself stays undrawn - it is in the scene and Godot renders it already - but which entities are
+		// inside it is not something that wireframe says.
+		PhysicsDebugDraw3D.FlashTargets(graphContext, _found, PhysicsDebugDraw3D.OverlapFoundColor);
+
 		var resolved = new IForgeEntity[_found.Count];
 		_found.CopyTo(resolved);
 		return resolved;

--- a/addons/forge/core/statescript/resolvers/ClosestEntity2DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/ClosestEntity2DResolver.cs
@@ -1,6 +1,7 @@
 // Copyright © Gamesmiths Guild.
 
 using Gamesmiths.Forge.Core;
+using Gamesmiths.Forge.Godot.Core.Statescript.Physics;
 using Gamesmiths.Forge.Statescript;
 using Gamesmiths.Forge.Statescript.Properties;
 using Godot;
@@ -65,6 +66,10 @@ internal sealed class ClosestEntity2DResolver(
 				closest = entity;
 			}
 		}
+
+		// The one thing it draws, and the reason it is worth drawing: the query that found the group already showed
+		// the group, and nothing in that wireframe says which of them this picked.
+		PhysicsDebugDraw2D.FlashTarget(graphContext, closest, PhysicsDebugDraw2D.OverlapFoundColor);
 
 		return closest;
 	}

--- a/addons/forge/core/statescript/resolvers/ClosestEntity3DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/ClosestEntity3DResolver.cs
@@ -1,6 +1,7 @@
 // Copyright © Gamesmiths Guild.
 
 using Gamesmiths.Forge.Core;
+using Gamesmiths.Forge.Godot.Core.Statescript.Physics;
 using Gamesmiths.Forge.Statescript;
 using Gamesmiths.Forge.Statescript.Properties;
 using Godot;
@@ -65,6 +66,10 @@ internal sealed class ClosestEntity3DResolver(
 				closest = entity;
 			}
 		}
+
+		// The one thing it draws, and the reason it is worth drawing: the query that found the group already showed
+		// the group, and nothing in that wireframe says which of them this picked.
+		PhysicsDebugDraw3D.FlashTarget(graphContext, closest, PhysicsDebugDraw3D.OverlapFoundColor);
 
 		return closest;
 	}

--- a/addons/forge/core/statescript/resolvers/EntitiesAtPoint2DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/EntitiesAtPoint2DResolver.cs
@@ -87,14 +87,8 @@ internal sealed class EntitiesAtPoint2DResolver(
 		PhysicsDebugDraw2D.FlashPoint(graphContext, position, color);
 
 		// The mark says where the question was asked; the outlines say what answered it. A point has no volume of its
-		// own to draw, so without them a hit and a miss differ only by the colour of a speck.
-		foreach (IForgeEntity entity in _found)
-		{
-			if (ForgeEntityBridge.TryGetSpatialNode2D(entity, out Node2D? spatialNode)
-				&& spatialNode is CollisionObject2D collider)
-			{
-				PhysicsDebugDraw2D.FlashBody(graphContext, collider, collider.GlobalTransform, color);
-			}
-		}
+		// own to draw, so with the outlines switched off a hit and a miss differ only by the colour of a speck - which
+		// is the trade this query pays more for than any other, and still the author's to make.
+		PhysicsDebugDraw2D.FlashTargets(graphContext, _found, color);
 	}
 }

--- a/addons/forge/core/statescript/resolvers/EntitiesAtPoint3DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/EntitiesAtPoint3DResolver.cs
@@ -87,14 +87,8 @@ internal sealed class EntitiesAtPoint3DResolver(
 		PhysicsDebugDraw3D.FlashPoint(graphContext, position, color);
 
 		// The mark says where the question was asked; the outlines say what answered it. A point has no volume of its
-		// own to draw, so without them a hit and a miss differ only by the colour of a speck.
-		foreach (IForgeEntity entity in _found)
-		{
-			if (ForgeEntityBridge.TryGetSpatialNode3D(entity, out Node3D? spatialNode)
-				&& spatialNode is CollisionObject3D collider)
-			{
-				PhysicsDebugDraw3D.FlashBody(graphContext, collider, collider.GlobalTransform, color);
-			}
-		}
+		// own to draw, so with the outlines switched off a hit and a miss differ only by the colour of a speck - which
+		// is the trade this query pays more for than any other, and still the author's to make.
+		PhysicsDebugDraw3D.FlashTargets(graphContext, _found, color);
 	}
 }

--- a/addons/forge/core/statescript/resolvers/EntitiesInCone2DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/EntitiesInCone2DResolver.cs
@@ -110,13 +110,15 @@ internal sealed class EntitiesInCone2DResolver(
 		}
 #pragma warning restore S3267 // Loops should be simplified using the "Where" LINQ method
 
-		PhysicsDebugDraw2D.FlashCone(
-			graphContext,
-			origin,
-			axis,
-			range,
-			halfAngle,
-			_inCone.Count > 0 ? PhysicsDebugDraw2D.OverlapFoundColor : PhysicsDebugDraw2D.OverlapEmptyColor);
+		Color color = _inCone.Count > 0
+			? PhysicsDebugDraw2D.OverlapFoundColor
+			: PhysicsDebugDraw2D.OverlapEmptyColor;
+
+		PhysicsDebugDraw2D.FlashCone(graphContext, origin, axis, range, halfAngle, color);
+
+		// The entities that passed the aperture test, not the ones the sphere found: a wireframe cone drawn over a
+		// crowd cannot say which of them the angle kept.
+		PhysicsDebugDraw2D.FlashTargets(graphContext, _inCone, color);
 
 		return [.. _inCone];
 	}

--- a/addons/forge/core/statescript/resolvers/EntitiesInCone3DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/EntitiesInCone3DResolver.cs
@@ -110,13 +110,15 @@ internal sealed class EntitiesInCone3DResolver(
 		}
 #pragma warning restore S3267 // Loops should be simplified using the "Where" LINQ method
 
-		PhysicsDebugDraw3D.FlashCone(
-			graphContext,
-			origin,
-			axis,
-			range,
-			halfAngle,
-			_inCone.Count > 0 ? PhysicsDebugDraw3D.OverlapFoundColor : PhysicsDebugDraw3D.OverlapEmptyColor);
+		Color color = _inCone.Count > 0
+			? PhysicsDebugDraw3D.OverlapFoundColor
+			: PhysicsDebugDraw3D.OverlapEmptyColor;
+
+		PhysicsDebugDraw3D.FlashCone(graphContext, origin, axis, range, halfAngle, color);
+
+		// The entities that passed the aperture test, not the ones the sphere found: a wireframe cone drawn over a
+		// crowd cannot say which of them the angle kept.
+		PhysicsDebugDraw3D.FlashTargets(graphContext, _inCone, color);
 
 		return [.. _inCone];
 	}

--- a/addons/forge/core/statescript/resolvers/LineOfSight2DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/LineOfSight2DResolver.cs
@@ -78,6 +78,10 @@ internal sealed class LineOfSight2DResolver(
 			clear ? to : blocker.Position,
 			clear ? PhysicsDebugDraw2D.SightClearColor : PhysicsDebugDraw2D.SightBlockedColor);
 
+		// Only on a block, and only the blocker: a clear line has nobody to name, and the thing that got in the way is
+		// what an author checking a failed line of sight is looking for.
+		PhysicsDebugDraw2D.FlashTarget(graphContext, blocker.Entity, PhysicsDebugDraw2D.SightBlockedColor);
+
 		return new Variant128(clear);
 	}
 }

--- a/addons/forge/core/statescript/resolvers/LineOfSight3DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/LineOfSight3DResolver.cs
@@ -78,6 +78,10 @@ internal sealed class LineOfSight3DResolver(
 			clear ? to : blocker.Position,
 			clear ? PhysicsDebugDraw3D.SightClearColor : PhysicsDebugDraw3D.SightBlockedColor);
 
+		// Only on a block, and only the blocker: a clear line has nobody to name, and the thing that got in the way is
+		// what an author checking a failed line of sight is looking for.
+		PhysicsDebugDraw3D.FlashTarget(graphContext, blocker.Entity, PhysicsDebugDraw3D.SightBlockedColor);
+
 		return new Variant128(clear);
 	}
 }

--- a/addons/forge/core/statescript/resolvers/Overlap2DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/Overlap2DResolver.cs
@@ -71,11 +71,12 @@ internal sealed class Overlap2DResolver(
 			_ignoreResolver?.ResolveArray(graphContext),
 			_found);
 
-		PhysicsDebugDraw2D.FlashShape(
-			graphContext,
-			shape,
-			transform,
-			_found.Count > 0 ? PhysicsDebugDraw2D.OverlapFoundColor : PhysicsDebugDraw2D.OverlapEmptyColor);
+		Color color = _found.Count > 0
+			? PhysicsDebugDraw2D.OverlapFoundColor
+			: PhysicsDebugDraw2D.OverlapEmptyColor;
+
+		PhysicsDebugDraw2D.FlashShape(graphContext, shape, transform, color);
+		PhysicsDebugDraw2D.FlashTargets(graphContext, _found, color);
 
 		var resolved = new IForgeEntity[_found.Count];
 		_found.CopyTo(resolved);

--- a/addons/forge/core/statescript/resolvers/Overlap3DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/Overlap3DResolver.cs
@@ -72,11 +72,12 @@ internal sealed class Overlap3DResolver(
 			_ignoreResolver?.ResolveArray(graphContext),
 			_found);
 
-		PhysicsDebugDraw3D.FlashShape(
-			graphContext,
-			shape,
-			transform,
-			_found.Count > 0 ? PhysicsDebugDraw3D.OverlapFoundColor : PhysicsDebugDraw3D.OverlapEmptyColor);
+		Color color = _found.Count > 0
+			? PhysicsDebugDraw3D.OverlapFoundColor
+			: PhysicsDebugDraw3D.OverlapEmptyColor;
+
+		PhysicsDebugDraw3D.FlashShape(graphContext, shape, transform, color);
+		PhysicsDebugDraw3D.FlashTargets(graphContext, _found, color);
 
 		var resolved = new IForgeEntity[_found.Count];
 		_found.CopyTo(resolved);

--- a/addons/forge/core/statescript/resolvers/Shapecast2DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/Shapecast2DResolver.cs
@@ -108,6 +108,8 @@ internal sealed class Shapecast2DResolver(
 			origin + motion,
 			hit ? PhysicsDebugDraw2D.RayHitColor : PhysicsDebugDraw2D.RayClearColor);
 
+		PhysicsDebugDraw2D.FlashTarget(graphContext, hitResult.Entity, PhysicsDebugDraw2D.RayHitColor);
+
 		// Only the entity survives, because a resolver returns one value. Everything else the sweep reported - where
 		// it landed, the surface normal, the collider, the distance - is what the Shapecast 2D node exists to give a
 		// graph, and is the reason the node form is not merely this resolver with ports.

--- a/addons/forge/core/statescript/resolvers/Shapecast3DResolver.cs
+++ b/addons/forge/core/statescript/resolvers/Shapecast3DResolver.cs
@@ -107,6 +107,8 @@ internal sealed class Shapecast3DResolver(
 			origin + motion,
 			hit ? PhysicsDebugDraw3D.RayHitColor : PhysicsDebugDraw3D.RayClearColor);
 
+		PhysicsDebugDraw3D.FlashTarget(graphContext, hitResult.Entity, PhysicsDebugDraw3D.RayHitColor);
+
 		// Only the entity survives, because a resolver returns one value. Everything else the sweep reported - where
 		// it landed, the surface normal, the collider, the distance - is what the Shapecast 3D node exists to give a
 		// graph, and is the reason the node form is not merely this resolver with ports.


### PR DESCRIPTION
Query wireframes say where a question was asked, never who answered it. Every entity-finding query now flashes the colliders it acquired, on the transition for the monitored nodes so outlines do not stack. A project setting turns it off for crowded scenes, inside Godot's own Visible Collision Shapes switch.