### PR TITLE
Added docs for the Godot-only nodes, resolvers and cue handlers.

### DIFF
--- a/addons/forge/core/statescript/nodes/state/NodeGroupNode.cs
+++ b/addons/forge/core/statescript/nodes/state/NodeGroupNode.cs
@@ -20,10 +20,12 @@ namespace Gamesmiths.Forge.Godot.Core.Statescript.Nodes.State;
 /// <para><b>Only a membership this node added is one it removes.</b> A node the level already put in the group is left
 /// in it, because the membership was never this ability's to take away - the same reasoning the override nodes use for
 /// restoring the value they found rather than the one they assume.</para>
-/// <para>The consequence is that two of these held over the same node and group resolve to whichever ends
-/// <em>first</em>, where the override nodes resolve to whichever ends last. A group is a set and not a count, so the
-/// second hold has nothing to add and nothing to restore; if two abilities need to mark the same node independently,
-/// give them a group each.</para>
+/// <para>The consequence is that the membership lasts exactly as long as the hold that <em>added</em> it. A second
+/// hold over the same node and group is a no-op in both directions - it adds nothing on activation and removes
+/// nothing on deactivation - so the node leaves the group when the adding hold ends, whether that is before or after
+/// the other one. This is not a reference count, and it is not the "whichever ends last" the override nodes give. A
+/// group is a set, so the second hold has nothing to add and nothing to restore; if two abilities need to mark the
+/// same node independently, give them a group each.</para>
 /// <para>The membership is not persistent, so it belongs to the running game and is never saved into the scene.</para>
 /// </remarks>
 /// <param name="group">The group to hold the node in.</param>

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,7 @@ Cues connect the gameplay simulation layer with the presentation layer, translat
 - Triggers audio/visual feedback in response to gameplay events and effect changes.
 - Organizes cues and handlers using tags for flexible assignment.
 - Passes custom parameters for feedback intensity, color, sound, and more.
+- Ships a [handler library](nodes.md#cue-handler-library) for particles, spawned scenes, audio, animation, camera shake and hit stop, so the common hookups need no C#.
 
 ### Statescript System
 
@@ -93,6 +94,7 @@ Statescript is a state-based scripting system for defining ability behaviors:
 - **Subgraphs**: State nodes own downstream subgraphs, providing automatic lifetime management and cleanup.
 - **Variables**: Mutable graph variables and entity-level shared variables connect graph logic to runtime data.
 - **Property Resolvers**: Data-driven inputs from attributes, tags, comparisons, and activation context.
+- **Engine Access**: Godot-only nodes and resolvers for the scene tree, transforms, physics queries, animation and more.
 - **Ability Integration**: Graphs plug directly into the Abilities system as `IAbilityBehavior` implementations.
 - **Visual Editor**: Built-in Statescript graph editor integrated into the Godot editor for visual authoring.
 

--- a/docs/helper-classes.md
+++ b/docs/helper-classes.md
@@ -19,6 +19,55 @@ var cuesManager = ForgeManagers.Instance.CuesManager;
 var tag = Tag.RequestTag(tagsManager, "ability.damage.fire");
 ```
 
+## ForgeEntityBridge
+
+The canonical translation between Godot scene nodes and `IForgeEntity`.
+
+**Description:**
+
+Forge supports two authoring patterns, and this static class is the only place that knows about both:
+
+- **Composition**: a plain `ForgeEntity` node parented under the visual or physics root. The spatial node is an *ancestor* of the entity.
+- **Direct**: a body script that implements `IForgeEntity` itself. The spatial node *is* the entity.
+
+Every spatial node, Statescript resolver, and cue handler resolves through here instead of guessing inline, so both patterns keep working and the guess only ever has to be fixed in one place. Use it in your own code for the same reason.
+
+**Lookups:**
+
+| Method | Answers |
+|---|---|
+| `TryGetEntity(node, out entity)` | The entity for a node, checking the node itself then its direct children. The narrow case: a collider that was just hit. |
+| `TryGetEntityInHierarchy(node, out entity)` | The same, widening up the ancestor chain. Physics reports the collider it hit, which is often a hurtbox nested under the body that owns the entity. |
+| `TryGetEntityNode(entity, out node)` | The Godot node backing an entity. |
+| `TryGetOwningNode(entity, out node)` | "The node this entity lives on", with no dimension: the nearest spatial ancestor of *either* kind, falling back to the entity's own node. |
+| `TryGetSpatialNode3D` / `TryGetSpatialNode2D` | The spatial node of a given dimension, with `nodePath` overloads so `%CastPoint` markers work everywhere. |
+| `TryGetEntityChild(entity, nodePath, out child)` | A child that is neither spatial nor the entity itself — an animation player, an audio player, an emitter. **An empty path means the first matching child**, one level deep, first match wins, which is not what an empty path means in the spatial lookups. |
+
+```csharp
+if (ForgeEntityBridge.TryGetEntityInHierarchy(hit.GetCollider() as Node, out IForgeEntity? target))
+{
+    _effectApplier.ApplyEffects(target, effectOwner: Owner, effectSource: this);
+}
+```
+
+## IInstantiationReceiver
+
+Implement this on the root script of a scene that Forge instantiates, and it is handed its ownership when it enters the tree:
+
+```csharp
+void OnInstantiated(IForgeEntity? owner, IForgeEntity? source);
+```
+
+`owner` is the entity that owns the effects the instance applies, usually the ability's owner; `source` is what is credited as causing them, which can be the instance's own entity when the spawned scene is a Forge entity in its own right.
+
+Both [`InstantiateScene`/`Scene` nodes](statescript/nodes/scene-nodes.md#the-instantiating-pair) (when **Pass ownership** is on) and [`InstantiateSceneCueHandler`](nodes.md#instantiatescenecuehandler) call it. It is what replaces a bespoke `Launch` method on a projectile: `ForgeProjectile3D` implements it, so a graph aims a projectile by spawning it rotated and nothing has to be called afterwards.
+
+## AudioPlayers
+
+A switch over Godot's three audio player types, which share no base class.
+
+Anything that means "the entity's audio player" without caring whether it is an `AudioStreamPlayer`, `AudioStreamPlayer2D` or `AudioStreamPlayer3D` goes through here. It is shared by the [Play Audio nodes](statescript/nodes/presentation-nodes.md#audio) and the [`AudioCueHandler`](nodes.md#audiocuehandler), so a path resolves the same way in a graph and in a cue.
+
 ## EffectApplier
 
 A helper class for applying effects from child effect nodes to target entities.
@@ -101,6 +150,7 @@ _effectApplier.ApplyEffects(targetNode, attackData, Owner, this, level: 2);
 
 **Notes:**
 
-- Make sure the target node (or a child) implements `IForgeEntity`.
+- Make sure the target node (or a child) implements `IForgeEntity`. `EffectApplier` resolves it through [`ForgeEntityBridge`](#forgeentitybridge), so both authoring patterns work.
 - For generic `ApplyEffects<TData>`, all ForgeEffect children must support the same TData type.
 - Add `[Tool]` and `[GlobalClass]` to custom node scripts for editor usability.
+- Before writing a projectile script like the one above, check whether [`ForgeProjectile3D`](nodes.md#forgeprojectile2d--forgeprojectile3d) already covers it — it does all of this, plus sweeping, piercing and distance falloff.

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -268,7 +268,7 @@ Extends Area2D/Area3D; travels along its own forward each physics step and appli
 - `Speed` (float): Units per second. Defaults to `10` in 3D and `400` in 2D.
 - `MaxLifetime` (float): Seconds before it expires. Default `5`.
 - `MaxRange` (float): Distance before it expires. Zero means unlimited.
-- `Pierce` (int): How many targets it passes through before stopping. Zero stops at the first.
+- `Pierce` (int): How many extra targets it hits before `DestroyOnHit` frees it. Zero frees it on the first. With `DestroyOnHit` off it is not a limit at all — the projectile keeps hitting until its lifetime or range ends.
 - `DistanceFalloffCurve` (Curve): Sampled at distance travelled over `MaxRange` and passed to the effects as context data.
 - `DestroyOnHit` (bool): Default on.
 - `IncludeAreas` (bool): Whether areas count as hits, as well as bodies.
@@ -287,6 +287,8 @@ It carries `ForgeEffect` children exactly as `EffectArea3D` does, and implements
 Two costs come with it. The cast is not free, and **the first enabled `CollisionShape` child becomes the query's shape** — a projectile built from several shapes or from a `CollisionPolygon` has no single shape to sweep and says so with a warning rather than silently sweeping one of them. That is why it is an export and not the only behavior.
 
 Pierce works by **re-sweeping with each collider it met excluded**, so a piercing shot reports everything along the step in the order it met them. The exclusion list is kept for the whole flight rather than per step, so a collider already answered for cannot stop the sweep again. The caster needs no special case: a projectile spawned inside its owner meets the owner on its first cast, skips it as the owner, and the exclusion that follows is exactly what should happen for the rest of the flight.
+
+`Pierce` counts down on every hit, but only `DestroyOnHit` acts on the count reaching zero — so an endlessly piercing beam-like projectile is `DestroyOnHit` off, bounded by `MaxLifetime` or `MaxRange` instead.
 
 While swept, monitoring is switched off — nothing reads the overlap list any more, and an armed area pays for a test per step that decides nothing. The projectile stays *monitorable*, so areas watching for it still see it.
 

--- a/docs/nodes.md
+++ b/docs/nodes.md
@@ -259,6 +259,37 @@ Great for melee sweeps, cone attacks, or custom AoE checks.
 - Add the node, configure shape and properties.
 - Add ForgeEffect child nodes as needed.
 
+### ForgeProjectile2D / ForgeProjectile3D
+
+Extends Area2D/Area3D; travels along its own forward each physics step and applies its child ForgeEffect nodes to whatever it hits. The generic projectile, so a fireball, an arrow or a bullet is a scene rather than a C# class.
+
+**Properties:**
+
+- `Speed` (float): Units per second. Defaults to `10` in 3D and `400` in 2D.
+- `MaxLifetime` (float): Seconds before it expires. Default `5`.
+- `MaxRange` (float): Distance before it expires. Zero means unlimited.
+- `Pierce` (int): How many targets it passes through before stopping. Zero stops at the first.
+- `DistanceFalloffCurve` (Curve): Sampled at distance travelled over `MaxRange` and passed to the effects as context data.
+- `DestroyOnHit` (bool): Default on.
+- `IncludeAreas` (bool): Whether areas count as hits, as well as bodies.
+- `Swept` (bool): Default on — see below.
+
+**Description:**
+
+Moves −Z in 3D and +X in 2D, so **aim is simply instantiation rotation**: binding [`InstantiateScene3DNode`](statescript/nodes/scene-nodes.md#the-instantiating-pair)'s Rotation to core's `LookAt` — or the 2D node's Rotation to an angle — is the whole launch story, and there is no `Launch` method to call.
+
+It carries `ForgeEffect` children exactly as `EffectArea3D` does, and implements `IInstantiationReceiver`, so owner and source arrive from whatever spawned it. On a hit it resolves the target through [`ForgeEntityBridge`](helper-classes.md#forgeentitybridge) and applies its effects with the falloff sampled from the curve.
+
+**Signals:** `Hit(Node)` and `Expired()`.
+
+**`Swept` closes the tunnelling question, and defaults on.** An area is tested for overlaps once per physics step, so a projectile whose step is longer than a wall is thick was never tested anywhere inside that wall and appeared on the far side of it. Swept, each step is a shape cast along the motion instead, and the projectile is placed *at* the impact rather than past it on the step that ends it.
+
+Two costs come with it. The cast is not free, and **the first enabled `CollisionShape` child becomes the query's shape** — a projectile built from several shapes or from a `CollisionPolygon` has no single shape to sweep and says so with a warning rather than silently sweeping one of them. That is why it is an export and not the only behavior.
+
+Pierce works by **re-sweeping with each collider it met excluded**, so a piercing shot reports everything along the step in the order it met them. The exclusion list is kept for the whole flight rather than per step, so a collider already answered for cannot stop the sweep again. The caster needs no special case: a projectile spawned inside its owner meets the owner on its first cast, skips it as the owner, and the exclusion that follows is exactly what should happen for the rest of the flight.
+
+While swept, monitoring is switched off — nothing reads the overlap list any more, and an armed area pays for a test per step that decides nothing. The projectile stays *monitorable*, so areas watching for it still see it.
+
 ## Cue Nodes
 
 ### ForgeCueHandler (Abstract)
@@ -271,7 +302,11 @@ Base node for implementing handlers for visual and audio feedback.
 
 **Description:**
 
-Extend `ForgeCueHandler` to implement custom logic for visual/audio response to gameplay events. Registers and unregisters with the Forge CuesManager automatically.
+Extend `ForgeCueHandler` to implement custom logic for visual/audio response to gameplay events. Registers and unregisters with the Forge CuesManager automatically. Before writing one, check whether the [cue handler library](#cue-handler-library) below already covers it.
+
+Each phase has **two overloads**: one taking the target entity, and one taking only the parameters. Override the second when the effect belongs to the screen rather than to whoever was hit — that is what the camera shake and hit stop handlers do.
+
+`WarnOnce(message)` reports a misconfiguration — a path pointing at nothing, a curve on an emitter that cannot scale — exactly once per message rather than once per application. One handler serves every target of its cue, so a bad path is wrong for all of them, and suppressing per *message* rather than per handler stops a handler's first problem hiding its second.
 
 **Usage:**
 
@@ -314,10 +349,84 @@ public partial class DamageCueHandler : ForgeCueHandler
 }
 ```
 
+## Cue Handler Library
+
+Six concrete handlers ship with the plugin, so the common visual and audio hookups need no C# at all. Add one to the scene, set its `CueTag`, and fill in its exports.
+
+All six inherit `CueTag` and `WarnOnce` from [`ForgeCueHandler`](#forgecuehandler-abstract). **(M)** marks an optional `MagnitudeCurve`, sampled at the cue's normalized magnitude.
+
+### ParticlesCueHandler
+
+Drives a particle emitter already in the target's scene, which is what keeps the material, draw pass and local-coords flag where an artist authored them.
+
+- `ParticlesPath` (string): Path to the emitter, from the node the target lives on. Empty means the target's first emitter child.
+- `OneShotOnExecute` (bool, default on): Executing restarts the emitter rather than only switching emission on.
+- `MagnitudeCurve` (Curve) **(M)**: Written as the emitter's amount ratio.
+
+Applying starts emission, removing stops it, executing bursts. One class covers all four emitter types; they share no base class in Godot, so the operations switch over them. **The magnitude curve reaches only the GPU pair** — `amount_ratio` is the one knob that scales emission without reallocating the particle buffer, and the CPU emitters do not have it, so a curve on one says so rather than silently doing nothing.
+
+### InstantiateSceneCueHandler
+
+The general-purpose visual: a telegraph, an impact burst, a shield bubble, a scorch mark.
+
+- `Scene` (PackedScene)
+- `Attach` (CueAttachMode): `TargetEntity` or `World`.
+- `Lifetime` (float): Seconds an executed instance lives. Zero or less leaves it to free itself.
+- `MagnitudeCurve` (Curve) **(M)**: Multiplied into the scene's authored scale.
+
+Executing spawns and forgets; applying spawns and holds, and removing frees what it spawned — which is what ties a bubble to the effect that put it there. It reads a well-known `position` custom parameter when one is present, else the target's position.
+
+**Placement happens before parenting**, written as a local transform through the parent's, because `AddChild` readies the instance and a scene that measures its own position in `_Ready` would otherwise see the position the scene was authored at.
+
+### AudioCueHandler
+
+- `PlayerPath` (string): An existing audio player. Empty falls back to `Stream`, then to the target's first audio player child.
+- `Stream` (AudioStream): Creates a player on the target instead. Ignored when `PlayerPath` resolves.
+- `StopOnRemove` (bool, default on): Off lets a tail finish after the effect has gone.
+- `MagnitudeCurve` (Curve) **(M)**: Sets the volume as a linear gain where one is full.
+
+Two ways to say what plays: a path, for anything whose bus, attenuation or stream randomization is authored; or a bare stream, for the common case where a cue is one sound and adding a node to every entity that can receive it is the only obstacle. A created player matches the target's dimension, so a sound on a 3D character is positional without the cue saying so.
+
+**One player per target, not one per playback.** A player created per execution and freed on `Finished` never frees for a looping stream, so a hit cue firing ten times a second would stack ten never-freed players a second onto its target. `MaxPolyphony` keeps what made per-playback players attractive — repeated executes still overlap instead of cutting each other off.
+
+**The curve replaces the volume rather than scaling it.** The volume is written *onto* a shared player, so adding to it would compound: each application would read back a level that already included the last one, and the sound would walk up until it clipped. With a curve, the cue decides the level; without one, the player's own mix stands.
+
+### AnimationCueHandler
+
+- `PlayerPath` (string): Empty means the target's first animation player child.
+- `ApplyAnimation`, `ExecuteAnimation`, `RemoveAnimation` (string): One clip per phase.
+
+Three names rather than one animation with a mode, because a stun that starts, holds and ends is three different clips and the alternative is three handlers under three cue tags. A phase left empty plays nothing, which makes a one-phase cue a single filled field.
+
+### CameraShakeCueHandler
+
+- `Amplitude` (float, default `0.1`): In the camera's own units — world units in 3D, pixels in 2D.
+- `Duration` (float, default `0.25`): For an executed shake. Ignored while a cue is applied, which shakes until removal.
+- `MagnitudeCurve` (Curve) **(M)**: Scales the amplitude, so a scratch and a critical do not shake identically.
+
+### HitStopCueHandler
+
+- `TimeScale` (float, default `0.05`)
+- `Duration` (float, default `0.08`)
+- `MagnitudeCurve` (Curve) **(M)**: Scales the duration, so a heavier hit hangs longer.
+
+Writes `Engine.TimeScale` for a moment and restores whatever was in force before. It is global — that is what a hit stop *is* — which means two of them fighting over the same moment is one handler's stop, so put one in the scene and let cue tags decide when it fires.
+
+### The two screen effects
+
+`CameraShakeCueHandler` and `HitStopCueHandler` are the only handlers that **do not touch their target**: they read the cue's phase and nothing else, which is what "presentation only" turns out to mean in code. They are cue handlers rather than graph nodes for the same reason — nothing about a screen effect belongs to the entity that was hit, and a graph node that could shake the screen would be a node that has to know *which* screen.
+
+Three details they share:
+
+- **The shake writes the camera's offset, never its transform**, because a game's camera is nearly always driven by a rig that would fight a transform write every frame.
+- **Both count in wall clock, not frame delta.** A hit stop measured in scaled time at a twentieth speed would last twenty times as long as it says, and a shake driven by scaled time would crawl through exactly the hit stop it exists to punctuate.
+- **Both put back what they found** when they end or leave the tree, so a handler freed mid-effect cannot leave the whole game in slow motion with nothing left to undo it.
+
 ## Best Practices
 
 - Use **ForgeEntity** for any game object needing Forge's systems.
 - Use **EffectArea/RayCast/ShapeCast** for persistent environment effects and hazards, prefer these over custom code for triggers, traps, or fields.
+- Use **ForgeProjectile2D/3D** for linear projectiles rather than writing a mover; aim it by spawning it rotated.
 - Use **ForgeEffect** as a child to define the effects any effect-applier node will use.
-- Implement custom **ForgeCueHandler** nodes for all presentation feedback tied to gameplay events.
+- Reach for the **cue handler library** first, and implement custom **ForgeCueHandler** nodes for presentation it does not cover.
 - When in doubt, favor the provided nodes and resources, they handle complex cases (ownership, cleanup, stacking) automatically.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -413,6 +413,8 @@ This pattern works for simple and complex abilities alike; just expand the effec
 
 ## Setting Up Visual Feedback with Cues
 
+> **Check the library first.** Particles, a spawned scene, audio, an animation, camera shake and hit stop already have handlers that ship with the plugin — add the node, set its `CueTag`, fill in the exports. See the [cue handler library](nodes.md#cue-handler-library). The steps below are for feedback none of those covers.
+
 ### Step 1: Create a Cue Handler
 
 ```csharp
@@ -472,7 +474,7 @@ public partial class DamageCueHandler : ForgeCueHandler
 
 - Learn more about the [Forge nodes](nodes.md) provided by the plugin.
 - Browse all available [Forge resources](resources.md) for configuring effects, abilities, tags, and more.
-- Build ability behaviors visually with [Statescript](statescript/README.md).
+- Build ability behaviors visually with [Statescript](statescript/README.md) — including the spatial, physics, input and interop nodes that let a dash, a projectile or an area of effect be authored instead of coded. See [Reaching the Engine](statescript/README.md#reaching-the-engine).
 - Discover [helper classes](helper-classes.md) for streamlining common Forge workflows in Godot.
 - Explore the scenes in the `forge_samples` folder.
 - Check out the [core Forge documentation](https://github.com/gamesmiths-guild/forge/blob/main/docs/README.md) for advanced topics and reference.

--- a/docs/statescript/README.md
+++ b/docs/statescript/README.md
@@ -58,6 +58,23 @@ Messages flow from output ports to input ports. This propagation is **synchronou
 
 For the built-in node index and links to the core per-node documentation, see [Nodes](nodes/README.md).
 
+### Reaching the Engine
+
+The core Statescript library is engine-agnostic, so nothing in it knows about scenes, physics, cameras or input. Forge for Godot adds those as ordinary nodes and resolvers, which is what lets a dash, a projectile, an area of effect or a trap be authored without writing an `IAbilityBehavior`:
+
+| Concern | Nodes | Resolvers |
+|---------|-------|-----------|
+| Scenes and the tree | [Scene Nodes](nodes/scene-nodes.md) | [Scene Graph and Interop](resolvers/scene-graph-resolvers.md) |
+| Transforms and motion | [Spatial Nodes](nodes/spatial-nodes.md) | [Spatial Getters](resolvers/spatial-getters.md) |
+| Physics writes | [Physics Nodes](nodes/physics-nodes.md) | [Spatial Getters](resolvers/spatial-getters.md) |
+| Physics queries | [Physics Query Nodes](nodes/physics-query-nodes.md) | [Physics Queries](resolvers/physics-queries.md), [Shapes](resolvers/shapes.md) |
+| Animation and audio | [Presentation Nodes](nodes/presentation-nodes.md) | [Engine and Timing](resolvers/engine-resolvers.md) |
+| Input and aim | [InputActionNode](nodes/input-action-node.md) | [Input](resolvers/input-resolvers.md), [Camera and Aim](resolvers/camera-and-aim.md) |
+| Navigation | [Navigation Nodes](nodes/navigation-nodes.md) | [Navigation](resolvers/navigation-resolvers.md) |
+| A game's own scripts | [Interop Nodes](nodes/interop-nodes.md) | [Scene Graph and Interop](resolvers/scene-graph-resolvers.md) |
+
+Presentation driven by *effects* rather than by a graph goes through cues instead — see the [cue handler library](../nodes.md#cue-handler-library).
+
 ## Subgraphs
 
 State nodes have **Subgraph** output ports in addition to regular Event output ports. Both emit a regular message when the state node activates, but the critical difference is what happens when a disable signal is sent:
@@ -131,6 +148,7 @@ Statescript graphs must be **acyclic**. The framework validates this at graph co
 - [Variables and Data](variables.md): Variables, shared variables, and property resolvers.
 - [Statescript Enums](enums.md): Authoring integers by name, and naming a Switch's cases or a State Machine's states.
 - [Property Resolvers](resolvers/README.md): Index of the resolver set available in Forge for Godot, with local pages for Godot-specific resolver resources.
+- [Physics Debug Drawing](physics-debug-drawing.md): What the query nodes and resolvers draw, and the one switch that turns it on.
 - [Custom Statescript Nodes](nodes/custom-nodes.md): How to create custom Action, Condition, and State nodes for Godot.
 - [Custom Resolvers](custom-resolvers.md): Creating custom property resolvers to expose game-specific data.
 - [Custom Editors](custom-editors.md): Creating custom node and resolver editors for the Statescript graph editor.

--- a/docs/statescript/nodes/README.md
+++ b/docs/statescript/nodes/README.md
@@ -131,7 +131,9 @@ They live under `Gamesmiths.Forge.Godot.Core.Statescript.Nodes.*`, and every one
 
 ### The two update rails
 
-Anything that moves a body, steers an agent, or asks the physics world a question runs on the **fixed step** — Move To, Move Body, Rotate To, Look At, Nav Move To, Force Override, Overlap, Ray, Sweep and Line Of Sight, in both dimensions. Timers, `InputActionNode`, the presentation nodes and the scene lifetimes stay on the **frame**, because their delta is wall-clock time.
+Only **State** nodes have a rail: Action and Condition nodes run the moment a message reaches them, so a one-shot `Raycast`, `Shapecast`, `Set Velocity` or `Apply Impulse` executes on whatever pass delivered it and never waits for a tick.
+
+Among the State nodes, the ones that move a body, steer an agent, or poll the physics world update on the **fixed step** — Move To, Move Body, Rotate To, Look At, Nav Move To, Force Override, Overlap, Ray, Sweep and Line Of Sight, in both dimensions. Timers, `InputActionNode`, the presentation nodes and the scene lifetimes stay on the **frame**, because their delta is wall-clock time. Collision Override sits on neither: it writes once on activation and undoes it once on deactivation.
 
 The split is by what a node's delta *means*, not by what the node touches. A host that implements `IForgeEntity` itself must drive both rails; see [Ability Integration](../README.md#in-godot).
 

--- a/docs/statescript/nodes/README.md
+++ b/docs/statescript/nodes/README.md
@@ -4,7 +4,9 @@ This folder keeps Godot-specific node documentation alongside the canonical core
 
 Use the local pages here when a node needs Godot editor, resource, or authoring notes. Use the core docs for runtime behavior, ports, lifecycle, and C# API details.
 
-## Built-in Nodes
+**[Godot-only nodes](#godot-only-nodes)** — everything that reaches the scene tree, physics, input, navigation or a game's own scripts — have no core counterpart at all, so their pages here are the canonical reference for ports, settings and behavior as well as authoring.
+
+## Core Nodes
 
 | Category | Node | Core Docs | Godot Docs | Description |
 |----------|------|-----------|------------|-------------|
@@ -13,7 +15,6 @@ Use the local pages here when a node needs Godot editor, resource, or authoring 
 | **Action** | `ApplyEffectNode` | [Core Doc](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/nodes/action/apply-effect-node.md) | [ApplyEffectNode](apply-effect-node.md) | Applies one or more effects to one or more targets. |
 | **Action** | `CancelAbilitiesNode` | [Core Doc](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/nodes/action/cancel-abilities-node.md) | — | Cancels active abilities on an entity, selected by the ability tags they carry. |
 | **Action** | `CancelAbilityNode` | [Core Doc](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/nodes/action/cancel-ability-node.md) | — | Cancels the ability driving the current graph. |
-| **Action** | `DebugNode` | *(Godot-only)* | — | Prints a resolved input value of any supported type to the Godot console. Configured with the value type, an is-array flag, and an object type id, so it can inspect either lane. |
 | **Action** | `ExecuteCueNode` | [Core Doc](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/nodes/action/execute-cue-node.md) | [ExecuteCueNode](execute-cue-node.md) | Executes one or more one-shot cues on one or more targets. |
 | **Action** | `GrantAbilityPermanentlyNode` | [Core Doc](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/nodes/action/grant-ability-permanently-node.md) | — | Permanently grants an ability; writes the granted `AbilityHandle` to an object output. |
 | **Action** | `RaiseEventNode` | [Core Doc](https://github.com/gamesmiths-guild/forge/blob/main/docs/statescript/nodes/action/raise-event-node.md) | [RaiseEventNode](raise-event-node.md) | Raises an event on one or more target entities' event buses. |
@@ -50,6 +51,90 @@ Nodes with an object-lane output (the grant nodes' `AbilityHandle` output, the t
 
 Two more editors exist for narrower reasons: the `ForEachNode` editor types its `Array` input row from the variable bound to its `Element` output (the same "the bound variable types the read" rule `SetVariableNode` uses for its target), and both loop nodes seed a fresh `Condition` slot with a constant `true` — the loop's "keep going" default — instead of the bool zero value, which would leave a newly dropped node running no iterations at all.
 
+## Godot-only Nodes
+
+These have no core Forge counterpart: they reach the scene tree, the physics world, input, navigation and a game's own scripts, none of which the engine-agnostic library has a concept of. Their pages here are the canonical reference — ports, settings, inputs, behavior — as well as the authoring notes.
+
+They live under `Gamesmiths.Forge.Godot.Core.Statescript.Nodes.*`, and every one carries a `[StatescriptCategory]` that places it in a [subgroup](#node-categories-in-the-palette) of its archetype in the Add Node dialog.
+
+### Scene
+
+| Arch | Node | Docs | Description |
+|------|------|------|-------------|
+| **Action** | `InstantiateScene3DNode` / `2D` | [Scene Nodes](scene-nodes.md#the-instantiating-pair) | Instantiates a scene, parents and places it, and hands it owner and source. Fire and forget. |
+| **Action** | `QueueFreeNode` | [Scene Nodes](scene-nodes.md#queue-free) | Frees a node, guarded against one already freed. |
+| **Action** | `ReparentNode` | [Scene Nodes](scene-nodes.md#reparent) | Moves a node under a new parent. Stick-to-target, pick up and drop. |
+| **Action** | `AddToNodeGroupNode` | [Scene Nodes](scene-nodes.md#godot-groups) | Puts a node into a Godot group permanently. |
+| **Action** | `RemoveFromNodeGroupNode` | [Scene Nodes](scene-nodes.md#godot-groups) | Takes it out permanently. |
+| **State** | `Scene3DNode` / `2D` | [Scene Nodes](scene-nodes.md#the-instantiating-pair) | Owns the instance: spawns on activation, frees on deactivation, with an optional lifetime and an `OnLifetimeEnd` port. |
+| **State** | `NodeGroupNode` | [Scene Nodes](scene-nodes.md#godot-groups) | Holds a group membership for exactly as long as the ability, and removes only what it added. |
+
+### Spatial
+
+| Arch | Node | Docs | Description |
+|------|------|------|-------------|
+| **Action** | `SetPosition3DNode` / `2D` | [Spatial Nodes](spatial-nodes.md#instant-writers-action) | Moves an entity instantly. Blink and teleport. |
+| **Action** | `SetRotation3DNode` / `2D` | [Spatial Nodes](spatial-nodes.md#instant-writers-action) | Writes a rotation instantly. 2D takes radians. |
+| **Action** | `SetScale3DNode` / `2D` | [Spatial Nodes](spatial-nodes.md#instant-writers-action) | Growing zones. |
+| **Action** | `SetRotationToward3DNode` / `2D` | [Spatial Nodes](spatial-nodes.md#instant-writers-action) | Turns to face a point, once. |
+| **State** | `MoveTo3DNode` / `2D` | [Spatial Nodes](spatial-nodes.md#move-to) | Transform interpolation with easing and an arc. Non-solving; `OnArrived`. |
+| **State** | `MoveBody3DNode` / `2D` | [Spatial Nodes](spatial-nodes.md#move-body) | The solving move. Sweeps with `MoveAndCollide`; `OnArrived` and `OnBlocked` with the blocker. |
+| **State** | `RotateTo3DNode` / `2D` | [Spatial Nodes](spatial-nodes.md#rotate-to) | Turns over time to a rotation captured at activation; `OnAligned`. |
+| **State** | `LookAt3DNode` / `2D` | [Spatial Nodes](spatial-nodes.md#look-at) | Keeps facing a re-resolved target, with an optional turn-rate ceiling. |
+
+### Physics
+
+| Arch | Node | Docs | Description |
+|------|------|------|-------------|
+| **Action** | `SetVelocity3DNode` / `2D` | [Physics Nodes](physics-nodes.md#velocity-and-impulses-action) | Writes a character or rigid body's velocity. Dash, knockback. |
+| **Action** | `ApplyImpulse3DNode` / `2D` | [Physics Nodes](physics-nodes.md#velocity-and-impulses-action) | Rigid body impulse, with an optional offset. |
+| **Action** | `SetAngularVelocity3DNode` / `2D` | [Physics Nodes](physics-nodes.md#velocity-and-impulses-action) | Rigid body spin rate. |
+| **Action** | `ApplyTorqueImpulse3DNode` / `2D` | [Physics Nodes](physics-nodes.md#velocity-and-impulses-action) | The angular Apply Impulse. |
+| **Action** | `SetCollisionBits3DNode` / `2D` | [Physics Nodes](physics-nodes.md#collision-bits) | Permanent layer/mask write. |
+| **State** | `ForceOverride3DNode` / `2D` | [Physics Nodes](physics-nodes.md#force-override-state) | Holds a body's constant force and torque, restoring both on deactivate or abort. |
+| **State** | `CollisionOverride3DNode` / `2D` | [Physics Nodes](physics-nodes.md#collision-bits) | Held layer/mask change, restoring only the bits it acted on. |
+| **Condition** | `Raycast3DNode` / `2D` | [Physics Query Nodes](physics-query-nodes.md#raycast) | Routes on hit/miss and writes five hit outputs. |
+| **Condition** | `Shapecast3DNode` / `2D` | [Physics Query Nodes](physics-query-nodes.md#shapecast) | A raycast with thickness; the same five outputs. |
+| **State** | `Ray3DNode` / `2D` | [Physics Query Nodes](physics-query-nodes.md#monitored-casts-state) | The monitored ray: `OnHit`/`OnLost` plus hit and clear subgraphs. |
+| **State** | `Sweep3DNode` / `2D` | [Physics Query Nodes](physics-query-nodes.md#monitored-casts-state) | The monitored shapecast, same port shape. |
+| **State** | `Overlap3DNode` / `2D` | [Physics Query Nodes](physics-query-nodes.md#overlap) | Watches an existing area or a transient shape; per-entity `OnEntered`/`OnExited` plus occupancy subgraphs. |
+| **State** | `LineOfSight3DNode` / `2D` | [Physics Query Nodes](physics-query-nodes.md#line-of-sight) | Watches the line between two points and reports the blocker. |
+
+### Presentation
+
+| Arch | Node | Docs | Description |
+|------|------|------|-------------|
+| **Action** | `PlayAnimationOneShotNode` | [Presentation Nodes](presentation-nodes.md#animation) | Starts an animation and moves on. |
+| **Action** | `PlayAudioOneShotNode` | [Presentation Nodes](presentation-nodes.md#audio) | Plays an existing audio player once. |
+| **State** | `PlayAnimationNode` | [Presentation Nodes](presentation-nodes.md#animation) | Owns playback; `OnFinished`, and optionally stops on an early exit. |
+| **State** | `PlayAudioNode` | [Presentation Nodes](presentation-nodes.md#audio) | Holds audio for the node's lifetime. Channel hums, beam loops. |
+
+### Input and Navigation
+
+| Arch | Node | Docs | Description |
+|------|------|------|-------------|
+| **State** | `InputActionNode` | [InputActionNode](input-action-node.md) | Watches a button: `OnPressed`, `OnReleased`, and a `WhilePressed` subgraph. |
+| **State** | `NavMoveTo3DNode` / `2D` | [Navigation Nodes](navigation-nodes.md) | Steers a body along a navigation path; `OnReached` / `OnFailed`. |
+
+### Interop
+
+| Arch | Node | Docs | Description |
+|------|------|------|-------------|
+| **Action** | `SetNodePropertyNode` | [Interop Nodes](interop-nodes.md#properties) | Writes a value onto a scene node's property. |
+| **Action** | `SetNodeEnabledNode` | [Interop Nodes](interop-nodes.md#enabled-state) | Visibility, processing or monitoring, permanently. |
+| **Action** | `CallMethodNode` | [Interop Nodes](interop-nodes.md#methods-and-signals) | Calls a method with up to two typed arguments and a typed return. |
+| **Action** | `EmitSignalNode` | [Interop Nodes](interop-nodes.md#methods-and-signals) | Emits a signal with up to two typed arguments. |
+| **Action** | `DebugNode` | [Interop Nodes](interop-nodes.md#debug) | Prints a resolved input value of any supported type to the Godot console. |
+| **State** | `NodePropertyOverrideNode` | [Interop Nodes](interop-nodes.md#properties) | Holds a property value, restoring it on deactivate or abort. |
+| **State** | `NodeEnabledOverrideNode` | [Interop Nodes](interop-nodes.md#enabled-state) | The held form of Set Node Enabled. |
+| **State** | `SignalListenerNode` | [Interop Nodes](interop-nodes.md#methods-and-signals) | Watches a signal and emits `OnSignal` each time it fires. |
+
+### The two update rails
+
+Anything that moves a body, steers an agent, or asks the physics world a question runs on the **fixed step** — Move To, Move Body, Rotate To, Look At, Nav Move To, Force Override, Overlap, Ray, Sweep and Line Of Sight, in both dimensions. Timers, `InputActionNode`, the presentation nodes and the scene lifetimes stay on the **frame**, because their delta is wall-clock time.
+
+The split is by what a node's delta *means*, not by what the node touches. A host that implements `IForgeEntity` itself must drive both rails; see [Ability Integration](../README.md#in-godot).
+
 ## Node Categories in the Palette
 
 The **Add Node** dialog groups nodes by the archetype they derive from:
@@ -63,6 +148,21 @@ The **Add Node** dialog groups nodes by the archetype they derive from:
 
 Any concrete node type in a loaded assembly is discovered and categorized automatically, so a custom flow node deriving straight from `Node` appears under **Flow** with no plugin change. See [Custom Statescript Nodes](custom-nodes.md).
 
+### Subgroups
+
+`[StatescriptCategory("...")]` adds a **second level inside an archetype**. The archetypes and their colors are untouched — they group by Statescript behavior, which is the right top level — and a node without the attribute, which is every core node, stays directly under its archetype.
+
+The Godot-only nodes use `Scene`, `Spatial`, `Physics`, `Presentation`, `Input`, `Navigation` and `Interop`. Your own nodes can declare any category name; put it on the node class:
+
+```csharp
+[StatescriptCategory("Vehicles")]
+public sealed class SetThrottleNode : ActionNode { }
+```
+
+### Display names
+
+A node's palette name is derived from its type name, with `2D` and `3D` treated as one token — `SetPosition3DNode` reads as "Set Position 3D" rather than "Set Position3 D". Apply `[StatescriptDisplayName("...")]` when the derivation reads badly.
+
 ## Configurable Port Counts
 
 A node whose constructor argument decides how many ports it has — `SwitchNode`'s `caseCount`, `StateMachineNode`'s `stateCount` — is authored with that count on the node itself, and the editor draws exactly the ports the built graph will have. The count is persisted in `CustomData` under the constructor parameter name and passed to the constructor at build time.
@@ -71,12 +171,15 @@ Both of those nodes select their ports with an integer, so both can follow a [St
 
 Lowering a count removes the ports past the new end, and the connections attached to them are removed with it — as one undoable action, so a single undo brings both back.
 
-## Future Godot-specific Nodes
+## Adding New Node Pages
 
-Add new Godot-only node pages to this folder as they are implemented, and keep the table above linking both the canonical core docs and any Godot-specific authoring notes.
+Add new node pages to this folder as they are implemented, and keep the tables above linking both the canonical core docs and any Godot-specific authoring notes. A node with a core counterpart gets a page only when Godot authoring adds something; a Godot-only node always gets one, because there is nowhere else its ports and settings are written down.
+
+Where a family shares one authoring model — the four presentation nodes, the physics writers — document it as a single page with a section per node and link the table rows to the anchors, rather than splitting near-identical pages.
 
 ## Related Docs
 
 - [Custom Statescript Nodes](custom-nodes.md)
 - [Statescript Enums](../enums.md)
+- [Physics Debug Drawing](../physics-debug-drawing.md)
 - [Node Template](../templates/node-template.md)

--- a/docs/statescript/nodes/custom-nodes.md
+++ b/docs/statescript/nodes/custom-nodes.md
@@ -448,6 +448,28 @@ Because the reading side resolves members on `TData` by name, each `Name` must m
 
 Providers are discovered via reflection and shared as cached instances, so keep them stateless. Build everything fresh from the supplied `GraphContext` and `AbilityActivationDataInputs` inside `CreateData`. See [AbilityActivatorResolver](../resolvers/ability-activator-resolver.md).
 
+### Built-in activation data providers
+
+Forge for Godot ships the payload nearly every projectile, blink and ground-targeted skill needs first, so a game does not have to declare its own type and provider just to say where the player was aiming.
+
+```csharp
+public readonly record struct AimActivationData(
+    Vector3 Origin, Vector3 Direction, Vector3 TargetPoint);
+
+public sealed class AimActivationDataProvider : AbilityActivationDataProvider<AimActivationData>;
+```
+
+Declaring the three members makes the payload readable in graphs through the Activation Data resolver **and** sendable from graphs for sub-ability activation. Two helpers build it from scene code:
+
+- `AimActivationData.FromCamera(...)` — first or third person shooters.
+- `AimActivationData.FromMouseGround(...)` — top-down and isometric. Resolves against physics first and falls back to the horizontal plane through the source, so pointing at empty sky still yields a usable point. The direction is flattened, because a character aiming at the ground should turn rather than tilt.
+
+`AimActivationData2D` is the twin, with the same three members as `Vector2`s and its own provider. **Its two helpers are not the same two**: `FromMouse` replaces `FromMouseGround` and `FromFacing` replaces `FromCamera`, because a 2D camera has no forward and the way a character already points is what a stick-aimed or heading-aimed game has instead. `FromMouse` casts nothing — a 2D cursor already names a world point exactly, so a ray between the caster and it could only replace where the player pointed with whatever stands in the way. The point is clamped to the aim's reach instead.
+
+> **There is deliberately no target-entity member.** Activation-data members resolve through the value lane, which carries numbers and math structs but not object references, so an entity member would look bindable in the editor and never resolve. Entity targeting already has a home: the ability's own target.
+
+Sampling aim once at activation is also what makes an ability work under authority — see [input is client-local](input-action-node.md#input-is-client-local).
+
 ## Effect Context Data Providers
 
 This is the inverse of an activation data provider. Instead of reading values *out* of ability activation data, an effect context-data provider builds typed data *from* the current graph state and passes it *into* the effect pipeline when `ApplyEffectNode`/`EffectNode` apply an effect. Custom calculators and executions then read it with `EffectEvaluatedData.TryGetContextData<TData>`.
@@ -500,6 +522,10 @@ public sealed class DirectionContextProvider : EffectContextDataProvider<Directi
 Selecting `DirectionContextProvider` shows a **Direction** section with a Vector3 resolver (constant, variable, activation data, ...). Input value types must be supported by `Variant128`. Note that graph values use `System.Numerics` math types, so convert to Godot's (`new Vector3(v.X, v.Y, v.Z)`) when your `TData` stores Godot types.
 
 Providers are discovered via reflection and shared as cached instances, so keep them stateless. Build everything fresh from the supplied `GraphContext` and `EffectContextDataInputs` inside `CreateData`. See [EffectContextDataResolver](../resolvers/effect-context-data-resolver.md).
+
+### Built-in effect context data provider
+
+`FloatContextDataProvider` declares a single `Value` input typed `float`, which covers the common case of handing one number to a calculation — a damage falloff computed from distance, a charge fraction, a stack multiplier. Select it on `ApplyEffectNode`'s or `EffectNode`'s context-data row, bind the **Value** resolver, and read it back with `EffectEvaluatedData.TryGetContextData<float>`.
 
 ## Cue Custom Parameters Providers
 

--- a/docs/statescript/nodes/input-action-node.md
+++ b/docs/statescript/nodes/input-action-node.md
@@ -1,0 +1,60 @@
+# InputActionNode
+
+> **Runtime Type:** `Gamesmiths.Forge.Godot.Core.Statescript.Nodes.State.InputActionNode`
+>
+> **Add Node group:** State → **Input**
+
+This node is **Godot-only** — there is no core Forge counterpart, so this page is its reference rather than a Godot-authoring supplement to one.
+
+Watches a Godot input action while active: the "wait for a button before continuing" node. Unpaired — a button has no dimension.
+
+## Settings
+
+| Setting | Kind | Meaning |
+|---|---|---|
+| **Action** | text, with a project-action dropdown beside it | The input action name to watch. |
+| **Deactivate On Pressed** | checkbox, default off | Ends the node on the first press it sees, which is what makes a combo window a window. |
+
+## Ports
+
+| Index | Name | Kind | Emits |
+|---|---|---|---|
+| 4 | OnPressed | Event | On a press **this node saw**. |
+| 5 | OnReleased | Event | On a release this node saw. |
+| 6 | WhilePressed | Subgraph | Active for as long as the button is down. |
+
+## A button already held when the watch begins is not a press
+
+Every other polling node in the layer treats its first reading as a transition into whatever it found — [Overlap](physics-query-nodes.md#overlap) reports the entities already inside, [Line Of Sight](physics-query-nodes.md#line-of-sight) emits on its first check. Input cannot: the button that activated an ability is still down when the graph starts, so a first reading counted as an edge would fire `OnPressed` for a press that happened before the node existed, and a combo window opened inside a timer would trigger on a button nobody pressed inside it.
+
+The node splits the two halves instead. **The edges are changes the node itself saw; the subgraph follows the button's state.** That is what lets an ability activated by the very button it channels on start channelling at once while still requiring a real press for `OnPressed`.
+
+## Patterns
+
+| Skill | Chain |
+|---|---|
+| Hold-to-channel | `WhilePressed` containing a `LoopTimerNode`. |
+| Charged shot | `OnReleased`, with the elapsed time of a `TimerNode` scaling the magnitude. |
+| Combo window | **Deactivate On Pressed** on, inside a `TimerNode` subgraph, advancing a `StateMachineNode`. |
+
+## The action field
+
+One control serves this setting and the four [input resolvers](../resolvers/input-resolvers.md), so an action is authored the same way wherever it appears.
+
+The field is **free text with a dropdown of the project's actions beside it**, and it stays free text on purpose. The project's list is a *subset* of what the runtime accepts — Godot's own `ui_*` presets are valid and deliberately hidden from the list, and a game may register actions from code that no project setting knows about — so a plain dropdown would be authoritative about something it is not, and would rewrite a stored name the next time anything in the node was touched.
+
+A name the project does not define is drawn in the editor's warning colour with a tooltip saying so, while the value itself is left exactly as typed. The cue refreshes whenever the dropdown opens, which is when a name typed before its action existed stops being unknown.
+
+The dropdown reads the project's `input/<action>` settings — the same list, in the same order, that the Input Map tab shows — rather than the `InputMap` singleton, whose editor copy holds the *editor's* shortcuts. Feature overrides such as `input/skill_1.macos` are skipped, since they are a second setting under one action rather than a name anything can be watched by.
+
+## Input is client-local
+
+This node and the input resolvers read the local machine's input state. Authoritative or networked games should sample aim and button state **once at activation** into [`AimActivationData`](custom-nodes.md#built-in-activation-data-providers) rather than polling inside a server-side graph.
+
+Unlike the physics nodes, `InputActionNode` runs on the **frame** rail, because its delta is wall-clock time.
+
+## Related Docs
+
+- [Nodes Reference](README.md)
+- [Input Resolvers](../resolvers/input-resolvers.md) — `Input Action Pressed`, `Input Action Strength`, `Input Axis`, `Input Vector 2`
+- [Camera and Aim Resolvers](../resolvers/camera-and-aim.md)

--- a/docs/statescript/nodes/interop-nodes.md
+++ b/docs/statescript/nodes/interop-nodes.md
@@ -58,7 +58,7 @@ Switching monitoring off is now an ordinary state for an area to be in, so [`Are
 |---|---|---|---|---|
 | `CallMethodNode` | Action | **Method** (text); **Arg 1**; **Arg 2**; **Returns** | 0 Node; 1 Arg 1; 2 Arg 2 | Output 0 `Return` |
 | `EmitSignalNode` | Action | **Signal** (text); **Arg 1**; **Arg 2** | 0 Node; 1 Arg 1; 2 Arg 2 | — |
-| `SignalListenerNode` | State | **Signal** (text); **One Shot** | 0 Node | Port 4 `OnSignal` |
+| `SignalListenerNode` | State | **Signal** (text); **One Shot** (deactivates the node the first time the signal fires) | 0 Node | Port 4 `OnSignal` |
 
 **Arguments are filled in order, and the editor enforces it both ways.** The second argument's type is offered only once the first is set, and the second row is hidden unless both are — the runtime stops at the first gap, so a row shown on its own type alone would be one the author filled in and nothing passed. The rows are *required* rather than optional for the same reason: an optional row renders `(None)`, which would read as "no argument" while the runtime passed a zero to keep the positions right.
 

--- a/docs/statescript/nodes/interop-nodes.md
+++ b/docs/statescript/nodes/interop-nodes.md
@@ -1,0 +1,84 @@
+# Interop Nodes
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Core.Statescript.Nodes.Action` and `.State`
+>
+> **Add Node group:** Action → **Interop**, State → **Interop**
+
+These nodes are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They are the escape hatches into everything Forge deliberately has no concept of: a scene node's own properties, a game's own scripts, and Godot signals in both directions. All of them are dimension-neutral.
+
+## The Node row
+
+Every node here takes the same optional **Node** input at index 0. Unbound means the node the ability's owner lives on — the nearest spatial ancestor of either kind, falling back to the entity's own node when it belongs to no spatial hierarchy at all. "Act on me" is what an untouched row says.
+
+That lookup is the bridge's `TryGetOwningNode`, which is also what the [`Node From Entity`](../resolvers/scene-graph-resolvers.md#crossing-between-lanes) resolver resolves through, so the two cannot drift.
+
+## The conversion set
+
+One `InteropValueType` dropdown names both value and object lanes for every node here:
+
+`Bool`, `Int`, `Float`, `Vector2`, `Vector3`, `Vector4`, `Plane`, `Quaternion`, `Node` — plus an **Array** checkbox beside it, and a `None` entry where an argument may be absent.
+
+Both settings are declared `AffectsLayout`, so changing either rebuilds the node and the Value row's editor is chosen from the input type the rebuilt node declares.
+
+**Entity is deliberately not in that set.** Writing an entity to a Godot property can only ever mean writing the node it lives on. Spelled as a dropdown entry, that lookup happens silently inside one row; spelled as [`Node From Entity`](../resolvers/scene-graph-resolvers.md#crossing-between-lanes) feeding the row, it is a step the author can see and point at. Reading is the same in reverse through [`Entity From Node`](../resolvers/scene-graph-resolvers.md#crossing-between-lanes).
+
+## Properties
+
+| Node | Arch | Settings | Inputs |
+|---|---|---|---|
+| `SetNodePropertyNode` | Action | **Property** (text); **Type**; **Array** | 0 Node (optional); 1 Value (required) |
+| `NodePropertyOverrideNode` | State | the same three | 0 Node (optional); 1 Value (required) |
+
+`SetNodeProperty` is the direct answer to "Set Variable does not reach the scene nodes": graph variables are two in-memory bags and nothing observes them.
+
+`NodePropertyOverride` captures what it found on activation and restores it on deactivation *or abort*, so a cancelled ability cannot leave a light dimmed or a material swapped for the rest of the run. The Action form is for state meant to outlive the ability — the same pairing [`SetCollisionBits` and `CollisionOverride`](physics-nodes.md#collision-bits) have, for the same reason.
+
+Reading a property back is the [`Node Property`](../resolvers/scene-graph-resolvers.md#reading-a-nodes-own-state) resolver.
+
+**A property path that does not exist is loud.** `SetIndexed` answers an unknown path with nothing at all rather than with a complaint, so a typo would otherwise be a node that runs, reports success and changes nothing. The write checks that the object declares the path's first segment — the segment a typo lands in — before deciding anything is wrong.
+
+## Enabled state
+
+| Node | Arch | Settings | Inputs |
+|---|---|---|---|
+| `SetNodeEnabledNode` | Action | **Aspect** | 0 Node (optional); 1 Enabled (`bool`, required) |
+| `NodeEnabledOverrideNode` | State | **Aspect** | 0 Node (optional); 1 Enabled (`bool`, required) |
+
+**Aspect** is one of `Visible`, `Processing`, `PhysicsProcessing`, `Monitoring`, `Monitorable`.
+
+**Monitoring is an area's switch.** Godot puts `Monitoring` and `Monitorable` on `Area2D` and `Area3D` alone, so pointing one at a body warns and names the distinction: a body's collision *layer and mask* say which layers it occupies and scans, while monitoring says whether an area tracks what is inside it. The warning points at [Set Collision Bits and Collision Override](physics-nodes.md#collision-bits) instead.
+
+Switching monitoring off is now an ordinary state for an area to be in, so [`Area Overlaps`](../resolvers/physics-queries.md#entity-list-queries) and [Overlap](physics-query-nodes.md#overlap)'s existing-area mode report nobody rather than erroring. Worth noting for anything reading an area from C#: a behavior calling `GetOverlappingBodies` directly still errors, because the check belongs to each caller.
+
+## Methods and signals
+
+| Node | Arch | Settings | Inputs | Outputs / Ports |
+|---|---|---|---|---|
+| `CallMethodNode` | Action | **Method** (text); **Arg 1**; **Arg 2**; **Returns** | 0 Node; 1 Arg 1; 2 Arg 2 | Output 0 `Return` |
+| `EmitSignalNode` | Action | **Signal** (text); **Arg 1**; **Arg 2** | 0 Node; 1 Arg 1; 2 Arg 2 | — |
+| `SignalListenerNode` | State | **Signal** (text); **One Shot** | 0 Node | Port 4 `OnSignal` |
+
+**Arguments are filled in order, and the editor enforces it both ways.** The second argument's type is offered only once the first is set, and the second row is hidden unless both are — the runtime stops at the first gap, so a row shown on its own type alone would be one the author filled in and nothing passed. The rows are *required* rather than optional for the same reason: an optional row renders `(None)`, which would read as "no argument" while the runtime passed a zero to keep the positions right.
+
+**Emit Signal checks its argument count and refuses; Call Method does not.** The asymmetry is real rather than an oversight: a signal has one fixed arity to compare against, while a method has optional parameters and varargs. Godot's own error covers the other.
+
+**Signal Listener reports that a signal fired, never what it carried.** Godot matches a connection by arity — a callable taking fewer arguments than the signal emits is an error on every emission, not a silent truncation — so the listener is built with the signal's own argument count, read from `GetSignalList()`. Keeping it a pure trigger is the deliberate half: when the payload is the point, [Overlap](physics-query-nodes.md#overlap) reports the entity it found and Forge's own events carry typed data.
+
+## Debug
+
+| Node | Arch | Settings | Inputs |
+|---|---|---|---|
+| `DebugNode` | Action | value type; is-array; object type id | 0 Value |
+
+Prints a resolved input of any supported type to the Godot console. It reaches both lanes, which is why it carries the three-setting shape the interop nodes replaced with one enum — it has to switch between the value lane and every registered object variable type. Override `FormatDebugValue` on a [custom object variable type](../variables.md#adding-a-custom-object-variable-type) to control how your own types print.
+
+`DebugNode` lives in the Godot namespace like everything else on this page. It originally declared itself inside the engine-agnostic core's namespace despite shipping with the Godot layer; it was moved outright with no compatibility shim, so a graph resource that referenced the old name is recreated rather than migrated.
+
+## Related Docs
+
+- [Nodes Reference](README.md)
+- [Scene Graph and Interop Resolvers](../resolvers/scene-graph-resolvers.md) — `Node Property`, `Node From Entity`, `Entity From Node`, `Node Path`
+- [Scene Nodes](scene-nodes.md) — spawning, freeing, reparenting, groups
+- [Variables and Data](../variables.md)

--- a/docs/statescript/nodes/navigation-nodes.md
+++ b/docs/statescript/nodes/navigation-nodes.md
@@ -1,0 +1,51 @@
+# Navigation Nodes
+
+> **Runtime Types:** `Gamesmiths.Forge.Godot.Core.Statescript.Nodes.State.NavMoveTo3DNode` / `NavMoveTo2DNode`
+>
+> **Add Node group:** State → **Navigation**
+
+These nodes are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+`Nav Move To` steers an entity to a destination along a navigation path. It writes the body's velocity from the agent each fixed step and lets the game move it — the layering that keeps an ability out of the character controller's way.
+
+## Settings
+
+| Setting | Kind | Meaning |
+|---|---|---|
+| **Agent** | text, placeholder `NavigationAgent3D` | Path to an existing agent child. Empty takes the entity's own, matching the [presentation nodes](presentation-nodes.md#the-player-path). |
+| **Use Safe Velocity** | checkbox, default off | Steer with the agent's avoidance result instead of the raw path direction. |
+
+**The agent is authored and never created.** Avoidance radius and navigation layers are scene data belonging to the character, not to one ability. Turning on **Use Safe Velocity** for an agent with avoidance disabled warns and falls back to following the path directly, rather than steering with a velocity the agent never computes.
+
+## Inputs
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | Entity | `IForgeEntity` | Optional. Unbound means the ability's owner. |
+| 1 | Target | `Vector3` / `Vector2` | Required. **Re-read every step**, so binding it to a spatial getter makes this a chase. |
+| 2 | Speed | `double` | Required — an unbound row resolves to zero, which cannot drive a path. A negative speed is read as zero. |
+
+## Ports
+
+| Index | Name | Emits |
+|---|---|---|
+| 4 | OnReached | The agent arrived. |
+| 5 | OnFailed | The destination is unreachable, or there is no agent to steer with. |
+
+**Deactivating zeroes the body's velocity**, which covers arrival, failure and abort with one rule rather than three.
+
+## An unsynced map reports everything as unreachable
+
+The delicate part is not the avoidance callback. `NavigationServer.MapGetPath` hands back an empty path from a navigation map that has not synced yet, and an empty path makes `IsTargetReachable` report *every* destination as unreachable — so a walk ordered on the frame its level loaded would fail instantly, for no reason a player could see.
+
+The node stamps the physics frame it activated on and does not judge reachability until that number has moved.
+
+## Asking navigation questions
+
+The node walks; it does not answer. Branching on reachability, measuring how far a walk would be, or clamping a ground-targeted point onto walkable floor are the [navigation resolvers](../resolvers/navigation-resolvers.md).
+
+## Related Docs
+
+- [Nodes Reference](README.md)
+- [Navigation Resolvers](../resolvers/navigation-resolvers.md) — `Nav Reachable`, `Nav Path Length`, `Nav Closest Point`
+- [Spatial Nodes](spatial-nodes.md) — `Move To` and `Move Body`, the non-pathfinding moves

--- a/docs/statescript/nodes/physics-nodes.md
+++ b/docs/statescript/nodes/physics-nodes.md
@@ -1,0 +1,90 @@
+# Physics Nodes
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Core.Statescript.Nodes.Action` and `.State`
+>
+> **Add Node group:** Action → **Physics**, State → **Physics**
+
+These nodes are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They are the *writing* half of the physics set: velocity, impulses, sustained force and collision bits. The reading half — rays, sweeps, overlaps and sight lines — is on [Physics Query Nodes](physics-query-nodes.md).
+
+Every node here is a 2D/3D pair; the tables describe the 3D member, and [what differs in 2D](#what-differs-in-2d) is at the end.
+
+The Action nodes execute once and have no rail. Of the two State nodes, **Force Override reasserts on the fixed step**, because a write applied a different number of times per second on every machine is not the thrust the author wrote; Collision Override does no per-tick work at all — it writes once on activation and undoes it once on deactivation.
+
+## Shared rows
+
+- **Entity (input 0, optional).** Whose body to write to. Unbound means the ability's owner.
+- **Node (setting, text).** A path to the body, typically `%Body`. Unlike the [spatial nodes](spatial-nodes.md#node-paths), a path that misses here **falls back to the entity's own node** — see [below](#a-missing-marker-falls-back-to-the-body).
+
+## Velocity and impulses (Action)
+
+| Node | Settings | Inputs | Body types | Behavior |
+|---|---|---|---|---|
+| `SetVelocity3DNode` | Node | 1 Velocity (`Vector3`, required) | `CharacterBody3D`, `RigidBody3D` | Dash; knockback by aiming Entity at the target instead of the caster. |
+| `ApplyImpulse3DNode` | Node | 1 Impulse (`Vector3`, required); 2 At Offset (`Vector3`, optional) | `RigidBody3D` | An offset turns the push into a spin. |
+| `SetAngularVelocity3DNode` | Node | 1 Angular Velocity (`Vector3`, required) | `RigidBody3D` | An axis with the rate as its length. Zero stops a spin dead. |
+| `ApplyTorqueImpulse3DNode` | Node | 1 Torque (`Vector3`, required) | `RigidBody3D` | The angular Apply Impulse. No offset row: an offset is what turns a push into a spin, and this already is the spin. |
+
+**The angular half is narrower than the linear one, and the engine is why.** Angular velocity and torque exist only on a rigid body — a character body is turned by the game rather than by physics — so pointing an angular node at a `CharacterBody3D` warns and skips the write, naming [Set Rotation 3D and Rotate To 3D](spatial-nodes.md) instead of silently doing nothing.
+
+## Force Override (State)
+
+Holds a body's **constant** force and torque for as long as the node is active, capturing what it found on activation and restoring it on deactivation *or abort*. Thrusters, updrafts, tractor beams, a channelled pull — this is the only thing in the layer that expresses sustained acceleration.
+
+| Setting | Values |
+|---|---|
+| **Node** | text, placeholder `%Body` |
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | Entity | `IForgeEntity` | Optional. |
+| 1 | Force | `Vector3` | Optional. |
+| 2 | Torque | `Vector3` | Optional. |
+
+**Constant force, not repeated `ApplyForce`.** Godot accumulates an applied force per physics frame and clears it, so a node calling `ApplyForce` per update would push harder at 120fps than at 60. Writing the body's constant force hands the integration to the engine at its own rate. The capture-and-restore is what stops a cancelled ability leaving a body accelerating forever.
+
+**Both rows are captured independently**, so binding only one leaves the other's authored value alone. `RigidBody` only, for the same reason as the angular nodes.
+
+Its permanent counterpart needs no node of its own: a constant force is an ordinary property, so [`Set Node Property`](interop-nodes.md#properties) on `constant_force` writes one that outlives the ability.
+
+## Collision bits
+
+The permanent-and-held pair the whole layer uses for writes: the Action form is for state meant to outlive the ability, the State form for state that must not.
+
+| Node | Arch | Settings | Inputs |
+|---|---|---|---|
+| `SetCollisionBits3DNode` | Action | Field (`Layer`/`Mask`); Operation (`Clear`/`Set`); Node | 1 Bits (`int`, required) |
+| `CollisionOverride3DNode` | State | the same three | 1 Bits (`int`, required) |
+
+`CollisionOverride` captures the field on activation and restores it on deactivation *or abort*, so a cancelled dash cannot leave a character permanently intangible.
+
+**It restores only the bits it acted on**, not the whole field. Putting the captured snapshot back would undo everything else that touched the field while it was running — a second override on different bits, or a permanent `Set Collision Bits` — and resurrect the bits those deliberately changed. Two overrides on the *same* bits still resolve to whichever ends last; neither can know what the other found.
+
+Both work on any `CollisionObject`.
+
+## A missing marker falls back to the body
+
+The physics writers opt into a fallback the transform writers refuse: when the **Node** path resolves to nothing, they act on the entity's own node and warn once naming the path. Their `%Body` placeholder is why. Physics state lives on the body and nowhere else, so the path is a *route to the subject* rather than a different subject, and an entity authored without the marker still has a right answer.
+
+A node of the **wrong type** — a `Marker3D` where a body was required — warns separately, because an entity with no marker hits both cases in sequence and one silencing the other would restore exactly the invisibility this exists to fix.
+
+## Seeing the writes
+
+`SetVelocity` and `ApplyImpulse` draw an arrow at the body's position at its true world length, so a velocity arrow reaches where the body gets to in one second and an impulse that is far too strong looks it. `SetAngularVelocity` and `ApplyTorqueImpulse` draw an arrow along the spin axis with the rate as its length; `ForceOverride` holds an arrow for as long as the push lasts, following the body.
+
+All of it is gated on Godot's own **Debug → Visible Collision Shapes** and nothing else. See [Physics Debug Drawing](../physics-debug-drawing.md).
+
+## What differs in 2D
+
+- **A spin is a number.** `SetAngularVelocity2D` takes a `double` in radians per second and `ApplyTorqueImpulse2D` a `double` — a plane has one axis to turn around.
+- **The two angular nodes draw nothing**, which is the answer rather than an omission: a 2D spin is about an axis pointing out of the screen, so any arrow drawn in the plane would name a direction the spin does not have.
+- Everything else is a mechanical mirror: `SetVelocity2D`, `ApplyImpulse2D`, `ForceOverride2D` (whose Torque row is a `double`), `SetCollisionBits2D` and `CollisionOverride2D`.
+
+## Related Docs
+
+- [Nodes Reference](README.md)
+- [Physics Query Nodes](physics-query-nodes.md) — rays, sweeps, overlaps, sight lines
+- [Spatial Nodes](spatial-nodes.md) — the non-solving transform writers
+- [Spatial Getters](../resolvers/spatial-getters.md) — `Entity Velocity`, `Entity Angular Velocity`, `Character State`, `Character Motion`
+- [Physics Debug Drawing](../physics-debug-drawing.md)

--- a/docs/statescript/nodes/physics-query-nodes.md
+++ b/docs/statescript/nodes/physics-query-nodes.md
@@ -101,15 +101,17 @@ Watches a volume and reports the entities that enter and leave it. The port shap
 | **Area** | text, placeholder `%WeaponHitbox` | `ExistingArea` only. Empty means the entity's own node. |
 | **Include Areas** | checkbox, default off | Whether overlapping areas count as well as bodies. |
 
-| Index | Label | Type | Notes |
-|---|---|---|---|
-| 0 | Entity | `IForgeEntity` | Optional. **`ExistingArea` mode only** — it says *whose* area to read. |
-| 1 | Shape | `Shape3D` | `TransientShape` mode. Seeded with a Sphere. |
-| 2 | Position | `Vector3` | **Required**, seeded with `Entity Position 3D` so a fresh node means "around me". |
-| 3 | Rotation | `Quaternion` | Optional. |
-| 4 | Mask | `int` | Optional. |
-| 5 | Poll Interval | `double` | Optional. Seconds between polls; unbound polls every fixed step. |
-| 6 | Ignore | `IForgeEntity[]` | Seeded with the owner. |
+**The Source setting decides which rows exist.** The editor shows only the ones its mode reads, so a row you cannot see is one that mode would have ignored.
+
+| Index | Label | Type | Mode | Notes |
+|---|---|---|---|---|
+| 0 | Entity | `IForgeEntity` | ExistingArea | Optional. Says *whose* area to read. |
+| 1 | Shape | `Shape3D` | TransientShape | Seeded with a Sphere. |
+| 2 | Position | `Vector3` | TransientShape | **Required**, seeded with `Entity Position 3D` so a fresh node means "around me". |
+| 3 | Rotation | `Quaternion` | TransientShape | Optional. |
+| 4 | Mask | `int` | TransientShape | Optional. An existing area is filtered by **its own** collision mask in the scene, so the node has no mask to offer there. |
+| 5 | Poll Interval | `double` | both | Optional. Seconds between polls; unbound polls every fixed step. |
+| 6 | Ignore | `IForgeEntity[]` | both | Seeded with the owner. |
 
 | Kind | Index | Name | Notes |
 |---|---|---|---|

--- a/docs/statescript/nodes/physics-query-nodes.md
+++ b/docs/statescript/nodes/physics-query-nodes.md
@@ -1,0 +1,175 @@
+# Physics Query Nodes
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Core.Statescript.Nodes.Condition` and `.State`
+>
+> **Add Node group:** Condition → **Physics**, State → **Physics**
+
+These nodes are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They ask the physics world a question. Which shape a question takes decides whether it is a node or a [resolver](../resolvers/physics-queries.md):
+
+- **Compound results are nodes.** A cast reports a position, a normal, an entity, a node and a distance; one query writes all five atomically, so downstream reads cannot disagree with each other.
+- **Entity-list queries are resolvers**, so they feed `ForEach`, `Where` and `OrderBy` directly.
+- **Boolean checks that must work inside a lambda are resolvers.** [`Line Of Sight 3D`](../resolvers/physics-queries.md#narrowing-and-testing) has to be usable inside a `Where`; the node form on this page is for when you want the transitions and the blocker.
+
+Every node here is a 2D/3D pair, runs its queries on the **fixed step**, and takes the two operands the whole family shares:
+
+- **Mask (`int`, optional).** A collision mask, authored as a number. **Zero means every layer** — a mask of zero can never find anything, so reading it literally would make an unbound row silently disable the query it belongs to.
+- **Ignore (`IForgeEntity[]`, required, seeded).** The entities the query keeps off. It is a *list* and not a flag because both ends of a query sit inside a body: a ray from a character's own position starts at its feet, outside its own capsule by a hair, and a line drawn to `%CastPoint` on a target ends inside the target. A fresh row is seeded with the ability's owner — or with the owner and the target for the sight forms — so what the editor shows is what runs. Emptying it is how a query that reports everyone is authored.
+
+> The two mechanisms behind that one row differ by necessity: **casts exclude by RID**, because they must keep off a collider they would otherwise start inside, while **overlaps drop the entities from their results**. Nothing about authoring them differs.
+
+## One-shot casts (Condition)
+
+Both route the message to **True** when they hit and **False** when they do not, which spares every graph an Action-plus-Expression pair just to branch on a hit.
+
+### Raycast
+
+| Setting | Values |
+|---|---|
+| **Hit Areas** | checkbox, default off |
+| **Hit From Inside** | checkbox, default off |
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | Origin | `Vector3` | Required. |
+| 1 | Direction | `Vector3` | Required. |
+| 2 | Max Distance | `double` | Required. |
+| 3 | Mask | `int` | Optional. |
+| 4 | Ignore | `IForgeEntity[]` | Seeded with the owner. |
+
+Hitscan shots, line-of-sight gates, ground snap.
+
+### Shapecast
+
+A raycast with thickness. A fast projectile aimed at a thin target slips past a ray; a dash checked with one walks a character's shoulders into a wall.
+
+| Setting | Values |
+|---|---|
+| **Hit Areas** | checkbox, default off |
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | Shape | `Shape3D` | Required, seeded with a [Sphere](../resolvers/shapes.md). |
+| 1 | Origin | `Vector3` | Required. |
+| 2 | Direction | `Vector3` | Required. |
+| 3 | Max Distance | `double` | Required. |
+| 4 | Rotation | `Quaternion` | Optional. |
+| 5 | Mask | `int` | Optional. |
+| 6 | Ignore | `IForgeEntity[]` | Seeded with the owner. |
+
+**A swept cast is two queries.** `CastMotion` reports how far the shape got as a fraction and says nothing about what stopped it; `GetRestInfo` reports what is touching and takes no motion. The node runs the first, places the shape at the fraction it came back with, and runs the second there — with a collision margin, because a sweep stops the shape exactly touching and an exact touch is the one distance floating point cannot be relied on to report as a contact.
+
+### The five outputs
+
+Both casts, and both of their monitored counterparts, write the same five in the same order and with the same names, so a graph swapped from a ray to a sweep keeps every binding it had.
+
+| Index | Name | Type |
+|---|---|---|
+| 0 | Hit Position | `Vector3` |
+| 1 | Hit Normal | `Vector3` |
+| 2 | Hit Entity | `IForgeEntity` |
+| 3 | Hit Node | `Node` |
+| 4 | Distance | `double` |
+
+## Monitored casts (State)
+
+`Ray3DNode` and `Sweep3DNode` are the held forms of Raycast and Shapecast — **the shorter name is the monitored one in both pairs**. They re-resolve every input each step, so bound resolvers track whatever is moving, and they write the same five outputs.
+
+| Setting | Values | Meaning |
+|---|---|---|
+| **Hit Areas** | checkbox | As the one-shot forms. |
+| **Hit From Inside** | checkbox | `Ray` only. |
+| **One Shot** | checkbox, default off | Deactivate after the first hit. |
+
+| Port | Index | Kind | Emits |
+|---|---|---|---|
+| OnHit | 4 | Event | On the transition into hitting something. |
+| OnLost | 5 | Event | On the transition back to clear. |
+| WhileHit | 6 | Subgraph | Active for as long as it is hitting. |
+| WhileClear | 7 | Subgraph | Active for as long as it is not. |
+
+Beams, aim-lock, tether break; a dash that cancels the moment its corridor closes.
+
+## Overlap
+
+Watches a volume and reports the entities that enter and leave it. The port shape mirrors core's `ConditionMonitorNode`: two edges for the transitions, two subgraphs for the states between them — **the edges are per entity**, the subgraphs follow occupancy.
+
+| Setting | Values | Meaning |
+|---|---|---|
+| **Source** | `ExistingArea`, `TransientShape` | Whether the volume is an `Area3D` in the scene or a shape the query builds. |
+| **Area** | text, placeholder `%WeaponHitbox` | `ExistingArea` only. Empty means the entity's own node. |
+| **Include Areas** | checkbox, default off | Whether overlapping areas count as well as bodies. |
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | Entity | `IForgeEntity` | Optional. **`ExistingArea` mode only** — it says *whose* area to read. |
+| 1 | Shape | `Shape3D` | `TransientShape` mode. Seeded with a Sphere. |
+| 2 | Position | `Vector3` | **Required**, seeded with `Entity Position 3D` so a fresh node means "around me". |
+| 3 | Rotation | `Quaternion` | Optional. |
+| 4 | Mask | `int` | Optional. |
+| 5 | Poll Interval | `double` | Optional. Seconds between polls; unbound polls every fixed step. |
+| 6 | Ignore | `IForgeEntity[]` | Seeded with the owner. |
+
+| Kind | Index | Name | Notes |
+|---|---|---|---|
+| Output | 0 | Event Entity | Which entity an entered or exited event is about. |
+| Port | 4 | OnEntered | Once per entity that enters. |
+| Port | 5 | OnExited | Once per entity that leaves. |
+| Port | 6 | WhileOverlapping | Subgraph, active while anything at all is inside. |
+| Port | 7 | WhileEmpty | Subgraph, active while nothing is. |
+
+**Both modes poll and diff; neither subscribes to the area's signals.** One diff routine means the two modes report entry and exit identically, and it is what makes an entity with several colliders count once — a hurtbox leaving while a hitbox stays is not an exit. It also removes a connect/disconnect lifetime that would have to survive aborts and assembly reloads.
+
+**The first poll runs during activation**, so a trap triggers on the frame it arms, one entity per event. Because the node polls on the physics step and Godot's overlap list is per physics step, nothing is missed at any frame rate — at the default Poll Interval of zero the two rates are the same one. An authored interval is what skips overlaps that start and end between polls.
+
+Traps, melee hit windows, proximity triggers, auras.
+
+## Line Of Sight
+
+The node form of the [sight resolver](../resolvers/physics-queries.md#narrowing-and-testing): the same test, with the transitions named and the blocker reported. A `ConditionMonitorNode` over the resolver gets the edges but not the blocker, and names its ports for a question nobody phrases as true and false.
+
+| Setting | Values |
+|---|---|
+| **Deactivate When Blocked** | checkbox, default off |
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | From | `Vector3` | Required. Bind it to [`Entity Position 3D`](../resolvers/spatial-getters.md), which is what the resolver form seeds. |
+| 1 | To | `Vector3` | Required. |
+| 2 | Ignore | `IForgeEntity[]` | Required, seeded with an array of the owner **and** the target. |
+| 3 | Mask | `int` | Optional. |
+
+The Ignore row is required rather than optional here on purpose: leaving it unbound would have meant "ignore the owner and the target", which an array of exactly those two already spells. `IsOptional` exists only for inputs whose absence no resolver can reproduce.
+
+| Kind | Index | Name |
+|---|---|---|
+| Output | 0 | Blocker Entity |
+| Output | 1 | Blocker Node |
+| Output | 2 | Block Position |
+| Port | 4 | OnClear |
+| Port | 5 | OnBlocked |
+| Port | 6 | WhileClear (subgraph) |
+| Port | 7 | WhileBlocked (subgraph) |
+
+Channels that break on cover, tethers, aggro drop.
+
+## Masks are operands, not spinboxes
+
+Node settings render as enums, checkboxes and text — there is no numeric setting control — so a mask, a poll interval and a max distance are all **inputs**. That is the better answer anyway: a number that cannot come from a variable or scale with an ability level is the weaker half of the pair.
+
+## Filtering is composition
+
+No query node takes a filter or a predicate. Core's element-lambda resolvers already do this three ways: gate an event edge with `ExpressionNode` plus an `AttributeResolver`, filter an array with `ObjectWhereResolver` and `ElementEntityResolver`, or track a filtered population with `ConditionMonitorNode` over `Count(Where(Overlap3D(...))) > 0`.
+
+## What differs in 2D
+
+The whole family mirrors mechanically, with one difference: **`Overlap2D`'s and `Sweep2D`'s Rotation operands are angles in radians** rather than quaternions. The rotation guard disappears with them — every 3D query has to reject the zero quaternion an unfilled operand resolves to, while an unfilled angle is zero, which means "unturned".
+
+## Related Docs
+
+- [Nodes Reference](README.md)
+- [Physics Query Resolvers](../resolvers/physics-queries.md) — the entity-list and boolean forms
+- [Shape Resolvers](../resolvers/shapes.md) — what feeds a Shape row
+- [Physics Nodes](physics-nodes.md) — the writing half
+- [Physics Debug Drawing](../physics-debug-drawing.md)

--- a/docs/statescript/nodes/physics-query-nodes.md
+++ b/docs/statescript/nodes/physics-query-nodes.md
@@ -12,7 +12,7 @@ They ask the physics world a question. Which shape a question takes decides whet
 - **Entity-list queries are resolvers**, so they feed `ForEach`, `Where` and `OrderBy` directly.
 - **Boolean checks that must work inside a lambda are resolvers.** [`Line Of Sight 3D`](../resolvers/physics-queries.md#narrowing-and-testing) has to be usable inside a `Where`; the node form on this page is for when you want the transitions and the blocker.
 
-Every node here is a 2D/3D pair, runs its queries on the **fixed step**, and takes the two operands the whole family shares:
+Every node here is a 2D/3D pair and takes the two operands the whole family shares. **The one-shot Condition nodes cast the moment a message reaches them**; only the monitored State nodes below poll, and those poll on the fixed step.
 
 - **Mask (`int`, optional).** A collision mask, authored as a number. **Zero means every layer** — a mask of zero can never find anything, so reading it literally would make an unbound row silently disable the query it belongs to.
 - **Ignore (`IForgeEntity[]`, required, seeded).** The entities the query keeps off. It is a *list* and not a flag because both ends of a query sit inside a body: a ray from a character's own position starts at its feet, outside its own capsule by a hair, and a line drawn to `%CastPoint` on a target ends inside the target. A fresh row is seeded with the ability's owner — or with the owner and the target for the sight forms — so what the editor shows is what runs. Emptying it is how a query that reports everyone is authored.

--- a/docs/statescript/nodes/presentation-nodes.md
+++ b/docs/statescript/nodes/presentation-nodes.md
@@ -1,0 +1,74 @@
+# Presentation Nodes
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Core.Statescript.Nodes.Action` and `.State`
+>
+> **Add Node group:** Action → **Presentation**, State → **Presentation**
+
+These nodes are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They drive an animation player or an audio player that is already in the entity's scene. All four are **unpaired**: an `AnimationPlayer` is the same node whether the game is 2D or 3D, so they resolve from the nearest spatial ancestor of *either* kind.
+
+Each comes in a fire-and-forget Action and a State that owns the playback for its own lifetime.
+
+## The player path
+
+The **Player** setting is a path to the player, from the node the entity lives on. **An empty path means the entity's first matching child**, one level deep, first match wins — which is not what an empty path means anywhere else in the layer, and deliberately so: the [spatial getters](../resolvers/spatial-getters.md) read an empty path as the entity's own node because that node *is* a transform, and it is never an `AnimationPlayer`. Requiring a path here would make it mandatory in the overwhelmingly common case of a scene with exactly one player. Name the path when the player is nested inside an imported model scene.
+
+## Animation
+
+| Node | Arch | Settings | Ports |
+|---|---|---|---|
+| `PlayAnimationOneShotNode` | Action | Player; Animation | — |
+| `PlayAnimationNode` | State | Player; Animation; **Stop On Deactivate** (default on) | 4 `OnFinished` |
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | Entity | `IForgeEntity` | Optional. Unbound means the ability's owner. |
+| 1 | Speed | `double` | Optional. |
+| 2 | Blend | `double` | Optional. Cross-fade seconds. |
+
+`PlayAnimationNode` deactivates and emits `OnFinished` when the animation stops being the one playing. **One comparison answers three questions**: Godot reports `CurrentAnimation` only while the player is playing, so `CurrentAnimation != animation` covers the animation ending, something stopping the player, and another animation taking over — three endings a graph has no reason to tell apart, since in all three the node has stopped being the thing driving the character.
+
+**Stop On Deactivate** stops the player if the node is still driving it when it deactivates, which covers an abort, a subgraph ending and the graph stopping — what an interrupted cast needs. A natural finish cannot trigger it, because by then the animation is over.
+
+Melee swing timing, cast bars, windups.
+
+## Audio
+
+| Node | Arch | Settings | Ports |
+|---|---|---|---|
+| `PlayAudioOneShotNode` | Action | Player | — |
+| `PlayAudioNode` | State | Player; **Stop On Deactivate** (default on) | 4 `OnFinished` |
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | Entity | `IForgeEntity` | Optional. |
+| 1 | Volume Db | `double` | Optional. |
+| 2 | Pitch | `double` | Optional. |
+
+Audio has the same shape one step simpler: `IsPlaying` going false is the end. Channel hums, beam loops.
+
+The three Godot audio players derive from their dimension's spatial node and share no base, so an `AudioPlayers` switch written once resolves "the entity's player" for both these nodes and the [`AudioCueHandler`](../../nodes.md#audiocuehandler).
+
+## Zero is a value, so unbound cannot be zero
+
+Speed, Blend, Volume Db and Pitch are all optional inputs, and all four need a distinction the physics rows do not: **zero is meaningful for every one of them**, so "unbound" cannot be read off the zero a missing binding resolves to. They resolve as nullable, and a null leaves whatever the player itself was authored with — which is what makes an unbound Volume Db mean "the mix the sound designer set" rather than "0 dB".
+
+Blend is an input rather than a setting for the same reason a poll interval is: there is no numeric setting control, and a blend that varies with an ability level is then just a resolver.
+
+## A node that cannot play does not stall the ability
+
+If the player or the animation is missing, both state nodes warn and finish on their first update rather than holding themselves open. Their whole job is to be waited on, so a graph whose next step hangs off `OnFinished` would never continue and the ability would stay active until something aborted it — which for an ability with no timer is never. Nothing having started is the same answer as having stopped; the warning is what reports the misconfiguration.
+
+## Two recipes that replace nodes
+
+- **Animation-keyed hit windows.** Use an `AnimationPlayer` method track that raises a Forge event, and pick it up with core's `EventListenerNode`. Nothing in this family needs to know about keyframes.
+- **Bone-attached cast points.** Add a `BoneAttachment3D` child and point a [spatial getter's](../resolvers/spatial-getters.md) **Node** path at it.
+
+Clip length is readable before anything plays, through the [`Animation Length`](../resolvers/engine-resolvers.md#animation-length) resolver, so a timer feeding a windup cannot drift from the art it is pacing.
+
+## Related Docs
+
+- [Nodes Reference](README.md)
+- [Engine Resolvers](../resolvers/engine-resolvers.md) — `Animation Length`, `Engine Time`, `Delta Time`
+- [Forge Nodes](../../nodes.md#cue-handler-library) — the cue handler library, for presentation driven by effects rather than by a graph

--- a/docs/statescript/nodes/scene-nodes.md
+++ b/docs/statescript/nodes/scene-nodes.md
@@ -77,7 +77,9 @@ A Godot group is a name attached to scene nodes, and it is the one way to reach 
 
 All three are dimension-neutral: a group is a name in the scene tree, not a physics concept.
 
-**Only a membership the node added is one it removes.** `NodeGroup` checks whether the node was already in the group when it activated, and leaves it alone if it was — a node the level author put in the group was never this ability's to take away. The consequence is that two holds over the same node and group resolve to whichever ends *first*, where the value overrides in [Interop Nodes](interop-nodes.md) resolve to whichever ends last. A group is a set, not a count, so the second hold has nothing to add and nothing to give back; two abilities that need to mark the same node independently want a group each.
+**Only a membership the node added is one it removes.** `NodeGroup` checks whether the node was already in the group when it activated, and leaves it alone if it was — a node the level author put in the group was never this ability's to take away.
+
+The consequence is that **the membership lasts exactly as long as the hold that added it**, and a second hold over the same node and group is a no-op in both directions: it adds nothing on activation and removes nothing on deactivation. So the node leaves the group when the *adding* hold ends, whether that is before or after the other one — it is not a reference count, and it is not "whichever ends last" the way the value overrides in [Interop Nodes](interop-nodes.md) are. A group is a set, so the second hold has nothing to add and nothing to give back; two abilities that need to mark the same node independently want a group each.
 
 ## Related Docs
 

--- a/docs/statescript/nodes/scene-nodes.md
+++ b/docs/statescript/nodes/scene-nodes.md
@@ -26,10 +26,10 @@ They are a 2D/3D pair even though a scene carries its own dimension, because the
 | Index | Label | Type | Notes |
 |---|---|---|---|
 | 0 | Scene | `PackedScene` | Required. Authored with the **Constant** scene resolver, or read from a `Scene` variable. |
-| 1 | Position | `Vector3` / `Vector2` | Optional. **Unbound means "where the caster is"** — the Parent Entity's own node — rather than the world origin, which is the sane default for an instance that only cares about rotation. |
+| 1 | Position | `Vector3` / `Vector2` | Optional. **Unbound means "where the caster is"** rather than the world origin, which is the sane default for an instance that only cares about rotation. Under `Entity` parenting that is the Parent Entity's node; under the other two, where the Parent Entity row is not shown, it is the ability's owner. |
 | 2 | Rotation | `Quaternion` / `double` | Optional. Unbound, and in 3D a zero quaternion, leave the scene's authored rotation. |
-| 3 | Parent Entity | `IForgeEntity` | Optional, defaults to the ability's owner. What the instance is parented to under `Entity` parenting, **and what an unbound Position is read from in every mode**. |
-| 4 | Parent Node | `Node` | Optional. Only read under `Node` parenting. |
+| 3 | Parent Entity | `IForgeEntity` | **Shown under `Entity` parenting only.** What the instance is parented to, and what an unbound Position is measured from. |
+| 4 | Parent Node | `Node` | **Shown under `Node` parenting only.** |
 | 5 | Lifetime | `double` | **State nodes only.** Seconds before the node self-deactivates. Zero or less means "until aborted". |
 
 ### Outputs and ports

--- a/docs/statescript/nodes/scene-nodes.md
+++ b/docs/statescript/nodes/scene-nodes.md
@@ -1,0 +1,87 @@
+# Scene Nodes
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Core.Statescript.Nodes.Action` and `.State`
+>
+> **Add Node group:** Action → **Scene**, State → **Scene**
+
+These nodes are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They cover the two things a graph does to the scene tree itself: putting scenes into it, and moving or removing nodes already in it. Godot groups round it off, since a group is how a level names a set of nodes that no path or hierarchy walk can reach.
+
+## The instantiating pair
+
+`InstantiateScene3D`/`InstantiateScene2D` (Action) spawn and forget. `Scene3D`/`Scene2D` (State) own what they spawned: the instance is created on activation and freed on deactivation, so a summon lasts exactly as long as the node does.
+
+They are a 2D/3D pair even though a scene carries its own dimension, because the *transform* the graph hands them does not: Position and Rotation are a `Vector3` and a `Quaternion` in 3D, and a `Vector2` and an angle in radians in 2D.
+
+### Settings
+
+| Setting | Values | Meaning |
+|---|---|---|
+| **Parent** | `CurrentScene`, `Entity`, `Node` | Where the instance is added. `Entity` uses the Parent Entity row's node, `Node` uses the Parent Node row. |
+| **Pass ownership** | checkbox, default on | Calls `IInstantiationReceiver.OnInstantiated(owner, source)` on the instance with the ability's owner and source, which is how a spawned `ForgeProjectile3D` learns who fired it. |
+
+### Inputs
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | Scene | `PackedScene` | Required. Authored with the **Constant** scene resolver, or read from a `Scene` variable. |
+| 1 | Position | `Vector3` / `Vector2` | Optional. **Unbound means "where the caster is"** — the Parent Entity's own node — rather than the world origin, which is the sane default for an instance that only cares about rotation. |
+| 2 | Rotation | `Quaternion` / `double` | Optional. Unbound, and in 3D a zero quaternion, leave the scene's authored rotation. |
+| 3 | Parent Entity | `IForgeEntity` | Optional, defaults to the ability's owner. What the instance is parented to under `Entity` parenting, **and what an unbound Position is read from in every mode**. |
+| 4 | Parent Node | `Node` | Optional. Only read under `Node` parenting. |
+| 5 | Lifetime | `double` | **State nodes only.** Seconds before the node self-deactivates. Zero or less means "until aborted". |
+
+### Outputs and ports
+
+| Kind | Index | Name | Type | Notes |
+|---|---|---|---|---|
+| Output | 0 | Instance | `Node` | What was spawned. |
+| Output | 1 | Instance Entity | `IForgeEntity` | The entity on the instance, when it has one. |
+| Port | 4 | OnLifetimeEnd | Event | **State nodes only.** Emits when the lifetime elapses, as opposed to an abort. |
+
+**Placement happens before parenting.** The transform is applied as a *local* one through the parent's transform, because `AddChild` readies the instance and a scene that measures its own position in `_Ready` — `ForgeProjectile3D` recording where it launched from — has to see the position it was actually spawned at.
+
+## Queue Free
+
+Frees a node from the scene, guarded against a node that has already been freed. Unpaired: a node to free is a node in either dimension.
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | Node | `Node` | Required. |
+
+## Reparent
+
+Moves a node under a new parent — the stick-to-target, pick-up and drop primitive.
+
+| Setting | Values | Meaning |
+|---|---|---|
+| **Keep World Transform** | checkbox, default on | Off keeps the node's position *relative to its parent*, which is what attaching to a hand or a socket marker wants. |
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | Node | `Node` | Required. The node that moves. |
+| 1 | New Parent | `Node` | Required. The node it moves under. |
+
+Neither row falls back to the ability's owner, unlike the [interop nodes](interop-nodes.md): "reparent me" and "reparent onto me" are different questions and an empty row reads as neither. The three reparents Godot rejects outright — a node with no parent, a node moved onto itself, and a node moved under its own descendant — are checked here first and reported as authoring warnings instead of engine errors.
+
+## Godot groups
+
+A Godot group is a name attached to scene nodes, and it is the one way to reach a set assembled by hand across a level — every spawn point, every cover marker, a whole patrol. Reading a group is the [`Nodes In Node Group` and `Entities In Node Group` resolvers](../resolvers/scene-graph-resolvers.md#godot-groups); these three nodes write to one.
+
+| Node | Arch | Setting | Input | Behavior |
+|---|---|---|---|---|
+| `AddToNodeGroupNode` | Action | **Group** (text) | Node (required) | Puts the node in the group permanently. |
+| `RemoveFromNodeGroupNode` | Action | **Group** (text) | Node (required) | Takes it out permanently. |
+| `NodeGroupNode` | State | **Group** (text) | Node (required) | Holds the membership for as long as the node is active, removing it on deactivation *or abort*. |
+
+All three are dimension-neutral: a group is a name in the scene tree, not a physics concept.
+
+**Only a membership the node added is one it removes.** `NodeGroup` checks whether the node was already in the group when it activated, and leaves it alone if it was — a node the level author put in the group was never this ability's to take away. The consequence is that two holds over the same node and group resolve to whichever ends *first*, where the value overrides in [Interop Nodes](interop-nodes.md) resolve to whichever ends last. A group is a set, not a count, so the second hold has nothing to add and nothing to give back; two abilities that need to mark the same node independently want a group each.
+
+## Related Docs
+
+- [Nodes Reference](README.md)
+- [Scene Graph and Interop Resolvers](../resolvers/scene-graph-resolvers.md) — `Constant` (scene), `Node Path`, `Node From Entity`, the group readers
+- [Interop Nodes](interop-nodes.md)
+- [Forge Nodes](../../nodes.md#forgeprojectile2d--forgeprojectile3d) — `ForgeProjectile3D`, the scene these nodes most often spawn

--- a/docs/statescript/nodes/spatial-nodes.md
+++ b/docs/statescript/nodes/spatial-nodes.md
@@ -1,0 +1,129 @@
+# Spatial Nodes
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Core.Statescript.Nodes.Action` and `.State`
+>
+> **Add Node group:** Action → **Spatial**, State → **Spatial**
+
+These nodes are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They read and write the transform of the node an entity lives on. Every one is a 2D/3D pair; the tables describe the 3D member, and [what differs in 2D](#what-differs-in-2d) is listed at the end.
+
+## Shared rows
+
+Every node here takes the same two, which is what makes the family read consistently:
+
+- **Entity (input 0, optional).** Which entity to move or turn. Unbound means the ability's owner.
+- **Node (setting, text).** A path from the entity's spatial node to a descendant to act on instead — `%YawPivot`, `%TargetPoint`, `%Turret`. Scene-unique `%names` are searched outward from the entity's own scene, so a marker inside an instanced level is found; see [Node paths](#node-paths).
+
+The instant writers additionally share a **Space** setting (`Global` or `Local`) except where noted.
+
+## Instant writers (Action)
+
+| Node | Settings | Inputs | Behavior |
+|---|---|---|---|
+| `SetPosition3DNode` | Space; Node | 1 Position (`Vector3`, required) | Moves the entity instantly. Blink and teleport. |
+| `SetRotation3DNode` | Space; Node | 1 Rotation (`Quaternion`, required) | Writes a rotation instantly, preserving scale. |
+| `SetScale3DNode` | Node | 1 Scale (`Vector3`, required) | Growing zones. |
+| `SetRotationToward3DNode` | **Ignore height** (default on); Node | 1 Target (`Vector3`, required) | Turns to face a point, once. With Ignore height on, the turn stays level rather than pitching at a target's feet. |
+
+`SetRotationToward` faces where the target *was* at the instant it ran. For a facing that keeps following, use [Look At](#look-at).
+
+## Motion over time (State)
+
+All four run on the **fixed step**, not the frame — see [the two update rails](../README.md#in-godot).
+
+### Move To
+
+Interpolates the transform from where the entity is to a destination. **It does not solve collisions**: this is the leap, hook-and-pull and forced-reposition primitive, and it will move a body through a wall. Guard it with the [`Can Fit`](../resolvers/spatial-getters.md#the-physics-readers) resolver, or use [Move Body](#move-body) when the world has to stop it.
+
+| Setting | Values | Meaning |
+|---|---|---|
+| **Mode** | `Duration`, `Speed` | How the Value row is read. |
+| **Easing** | `Linear`, `EaseIn`, `EaseOut`, `EaseInOut` | Applied to progress. |
+| **Node** | text | As above. |
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | Entity | `IForgeEntity` | Optional. |
+| 1 | Destination | `Vector3` | Required. Captured at activation. |
+| 2 | Value | `double` | Required. Seconds under `Duration`, units per second under `Speed`. |
+| 3 | Arc Height | `double` | Optional. Raises the midpoint of the path, which is what makes a leap read as one. |
+
+Port 4 is **OnArrived**, emitted when the move completes rather than when it is aborted. Aborting stops the entity in place. An entity freed mid-move deactivates the node rather than leaving the ability waiting on an arrival that can never come.
+
+### Move Body
+
+The solving counterpart. Sweeps the body toward the destination with `MoveAndCollide` each fixed step and reports what stopped it. The resolved node must be a `PhysicsBody`, and it warns and skips the move when it is not.
+
+`MoveAndCollide` rather than `MoveAndSlide` is not an implementation detail: `MoveAndSlide` is the game's own character-controller entry point, is `CharacterBody`-only, and reads and writes the body's velocity while applying floor snapping and slope detection. An ability calling it would move the body a second time each step and fight the controller for ownership of that velocity — the exact layering mistake [Nav Move To](navigation-nodes.md) avoids by writing a velocity and letting the game move.
+
+| Setting | Values | Meaning |
+|---|---|---|
+| **Mode** | `Duration`, `Speed` | As Move To. |
+| **When Blocked** | `Stop`, `Slide` | Whether a refused step ends the move or slides along the surface. |
+| **Node** | text | As above. |
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | Entity | `IForgeEntity` | Optional. |
+| 1 | Destination | `Vector3` | Required. |
+| 2 | Value | `double` | Required. |
+
+| Kind | Index | Name | Notes |
+|---|---|---|---|
+| Output | 0 | Blocker Entity | The entity the move met, when it has one. |
+| Output | 1 | Blocker Node | The collider itself. |
+| Port | 4 | OnArrived | Reached the destination. |
+| Port | 5 | OnBlocked | Stopped short, or ran out of time under `Slide`. |
+
+**Both responses are time-bounded** by the duration the move would have taken unobstructed, which is what keeps `Slide` honest — a slide grinding along a wall forever is not something a graph can author by accident. Running out of time reports `OnBlocked`, because not arriving is what being blocked means; under `Slide` that is the only way it fires.
+
+There is no easing setting, and that is not an omission: distributing travel over time describes a path the body is no longer on the moment a collision displaces it.
+
+### Rotate To
+
+Turns to a rotation captured at activation, over a duration or at a rate.
+
+| Setting | Values |
+|---|---|
+| **Mode** | `Duration`, `Speed` — the same `MoveToMode` Move To uses |
+| **Node** | text |
+
+Inputs are Entity (0, optional), **Rotation** (1, `Quaternion`, required) and **Value** (2, `double`, required). Port 4 is **OnAligned**. A zero quaternion — what an unfilled operand resolves to — is rejected rather than turned to.
+
+### Look At
+
+The turn that keeps turning. The target is re-resolved every fixed step, so a bound [`Entity Position 3D`](../resolvers/spatial-getters.md) follows whoever is moving: a turret holding a lead, a beam that tracks, a boss keeping the player in front of it.
+
+| Setting | Values | Meaning |
+|---|---|---|
+| **Ignore height** | checkbox, default on | Keeps the turn level. |
+| **Node** | text | Typically `%YawPivot`. |
+
+| Index | Label | Type | Notes |
+|---|---|---|---|
+| 0 | Entity | `IForgeEntity` | Optional. |
+| 1 | Target | `Vector3` | Required, re-read every step. |
+| 2 | Speed | `double` | Optional ceiling in radians per second. Unbound snaps. |
+
+There is no aligned port: [`Is In Cone 3D`](../resolvers/physics-queries.md#narrowing-and-testing) over the caster's forward is the layer's aim test. The lag a speed ceiling creates is the point — it is what makes a tracking attack dodgeable, which is why the rate is a maximum rather than a rate to be met.
+
+## Node paths
+
+A `%name` in the **Node** setting is searched **outward from the graph's entity**, innermost scene first, rather than down from the current scene. A game whose menu instantiates levels as children leaves `CurrentScene` pointing at the outer shell, which knows nothing about the names inside the level. Ordinary relative paths keep the current scene as their root; only `%names` get the walk, because only they have the registration problem.
+
+**A missing marker does not fall back here.** Every node on this page is pointed at a node that *is* the subject — substituting the entity's body would turn "rotate the turret" into "rotate the tank" — so a path that misses warns and skips the write. The physics writers are the opposite case; see [Physics Nodes](physics-nodes.md#a-missing-marker-falls-back-to-the-body).
+
+## What differs in 2D
+
+- **Rotation is a number.** `SetRotation2D` and `RotateTo2D` take a `double` in radians. Core's whole numeric toolbox — lerp, wrap, delta angle, deg-to-rad — applies to a facing directly, with no quaternion resolvers in between.
+- **`SetRotationToward2D` and `LookAt2D` have no Ignore height setting.** There is no pitch to suppress in a plane, so the 2D nodes are the flattened ones by construction.
+- **`RotateTo2D` resolves a signed delta once at activation** rather than interpolating two absolute angles, because a plane's rotation keeps counting past a full turn and lerping the raw numbers would go the long way round. It has no zero guard either, since zero radians is a facing a graph can genuinely mean.
+- **`MoveTo2D`'s arc subtracts**, because screen up is −Y.
+
+## Related Docs
+
+- [Nodes Reference](README.md)
+- [Spatial Getters](../resolvers/spatial-getters.md) — the reading half of this family
+- [Physics Nodes](physics-nodes.md) — velocity, impulses and collision bits
+- [Navigation Nodes](navigation-nodes.md) — `Nav Move To`, the pathfinding walk

--- a/docs/statescript/physics-debug-drawing.md
+++ b/docs/statescript/physics-debug-drawing.md
@@ -1,0 +1,61 @@
+# Physics Debug Drawing
+
+> **Runtime Types:** `Gamesmiths.Forge.Godot.Core.Statescript.Physics.PhysicsDebugDraw3D` / `PhysicsDebugDraw2D`
+
+An overlap shape, a ray and an impulse describe geometry that exists only for the instant it is asked about, which is exactly the geometry a scene view cannot show. Forge for Godot draws it.
+
+## There is nothing to author
+
+Drawing is gated entirely on Godot's own **Debug → Visible Collision Shapes** — the same switch that reveals the shapes that *are* in the scene. There is nothing to turn on per node, nothing to remember to turn off, and no second concept to learn.
+
+With the switch off every entry point returns on one flag read and allocates nothing. In the editor's own tree the flag is always off, so authoring draws nothing.
+
+## What gets drawn
+
+| Item | Drawn |
+|---|---|
+| `Overlap`, `Line Of Sight`, `Raycast` (resolvers and one-shot nodes) | Flashed for a third of a second where the query ran, coloured by the answer, so a blocked line, a missed ray or an overlap that caught nobody is told apart without reading a variable. |
+| `Entities In Cone` | The cone itself, not the sphere behind it. Godot has no cone collision shape and so no debug mesh to borrow, so the wireframe is built by hand: four edges to a rim that sits on the sphere the query actually swept. |
+| `Shapecast` (resolver and node), `Sweep` | The shape at its resting transform **and a line down the middle of the sweep at its full reach**. The outline alone says where the sweep stopped and nothing about where it came from; on a hit, the gap between the end of the line and the shape is the distance the sweep was stopped short by. This is what Godot's own `ShapeCast` gizmo draws, for the same reason. |
+| `Closest Entity` | The one it picked, outlined. It runs no query, so it draws no query geometry — but *which* of the group it chose is the one thing the query that found the group cannot show. |
+| `Entities At Point` | Short axis lines crossing on the point, coloured by the answer, **and the outline of every entity found**. A cross rather than a small sphere: the query has no radius, and anything with a volume would be read as its reach. |
+| `Can Fit` | A line from where the body is to where it was asked to fit, **and the body's own collision shapes drawn at that destination** — green when it fits, red when it does not. Every owner the body has is drawn and disabled ones are left out, so what appears is the geometry the answer was computed from. On a failure, the outline sitting inside whatever blocked it *is* the answer. |
+| `Force Override` | An arrow at the body's own position, held for as long as the push lasts and following it, so a thrust that is far too strong looks it. |
+| `Set Velocity`, `Apply Impulse` | An arrow at its true world length, so a velocity arrow reaches where the body gets to in one second. |
+| `Set Angular Velocity`, `Apply Torque Impulse` | An arrow along the spin axis with the rate as its length — the same reading `Entity Angular Velocity` reports. **Their 2D twins draw nothing**, and that is the answer rather than an omission: a 2D spin is a scalar about an axis pointing out of the screen, so any arrow drawn in the plane would name a direction the spin does not have. |
+| `Overlap` (State, transient), `Ray`, `Line Of Sight` (State) | Held for as long as the node is active, updated every poll, and recoloured by the answer: an armed trap reads as armed and turns as something steps into it, a beam as it acquires and loses. |
+| `Area Overlaps`, `Overlap` (State, existing area) | No shape. The area is in the scene and Godot already draws it; a second wireframe on top of the engine's is noise. The entities inside it are outlined, which the engine's wireframe does not say. |
+| `Is In Cone` | Nothing. It tests one point against numbers and touches no physics server. |
+
+## Outlining what a query found
+
+**A query's own geometry says where the question was asked; only an outline on the answer says who answered it.** A cleave drawn over a crowd shows a cone and leaves the author counting who was inside it by hand; a ray drawn through two overlapping characters says nothing about which one it reported.
+
+So every query that produces entities outlines them, in the query's own colour. **A one-shot query outlines on every run; a monitored one outlines on the transition** — the same rule the geometry follows, because an outline redrawn every poll would stack a fresh flash on the last one until the highlight was a permanently lit body. `Overlap` outlines each entity as it enters, `Ray` and `Sweep` outline what they just acquired, and `Line Of Sight` outlines whatever just blocked it.
+
+### The project setting
+
+**Project → Project Settings → General**, under **Forge → Statescript → Highlight Query Targets**. It is a basic setting, so no Advanced Settings toggle is needed to see it.
+
+`forge/statescript/highlight_query_targets`, **default on**, and consulted only when Visible Collision Shapes is already on. Enabling the plugin declares it, so it is there to switch off from the first run.
+
+It does not appear in `project.godot` until you actually change it: Godot skips saving a property whose value still equals its initial value, which is what keeps an untouched project's file clean.
+
+Per-query checkboxes were the alternative and would have been twenty settings answering one question, against the rule that debug drawing is never authored. The answer is the same for every query in a project and it is a developer preference, which is exactly what a project setting is for — and the reason to have a switch at all is that a crowded scene is where the outlines are most useful *and* most overwhelming, which is a judgement no default can make. With it off, the query geometry and its colour still say whether anything was found.
+
+## How it is drawn
+
+Line geometry is one shared `ImmediateMesh` per marker and shapes reuse `Shape3D.GetDebugMesh()` — the same mesh Godot draws for a collision shape — so a monitored query stays allocation-free once it is running.
+
+Markers are parented to the **owner's own viewport** rather than to the main scene, so a game rendering its world inside a sub-viewport draws its debug geometry in that world instead of an empty one.
+
+**2D needs a script**, because a canvas item has no counterpart to a mesh instance holding geometry: everything a `CanvasItem` shows comes out of its own `_Draw`. `PhysicsDebugMarker2D` is that script. It holds either a shape and its transform or a run of segments, and redraws whichever it was last given; shapes reach `Shape2D.Draw`, the same call Godot makes for a collision shape in the scene, so both dimensions borrow the engine's own drawing rather than reimplementing it.
+
+Two 2D details are not transcriptions of the 3D side: the container node is named apart from the 3D one, because both dimensions can be alive in one viewport and a container found by name would be the wrong kind of node for whichever created it second; and the arrow head is capped in **pixels** rather than metres, since that is what a 2D world measures distance in.
+
+## Related Docs
+
+- [Statescript](README.md)
+- [Physics Query Nodes](nodes/physics-query-nodes.md)
+- [Physics Nodes](nodes/physics-nodes.md)
+- [Physics Query Resolvers](resolvers/physics-queries.md)

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -72,7 +72,7 @@ Object-backed graph values are keyed by an object variable type. In addition to 
 | Type id | Display name | Backing type | Used by |
 |---------|--------------|--------------|---------|
 | `Tag` | Tag | `Tag` | The tag listener's output. |
-| `AbilityHandle` | Ability Handle | `AbilityHandle` | The grant nodes' handle output and the lookup resolvers. |
+| `AbilityHandle` | Ability | `AbilityHandle` | The grant nodes' handle output and the lookup resolvers. |
 | `AbilityData` | Ability Data | `AbilityData` | The ability grant inputs. |
 | `GodotNode` | Node | `Godot.Node` | Everything in the node lane — spawn outputs, hit nodes, the interop rows. |
 | `Scene` | Scene | `Godot.PackedScene` | The scene `Constant` resolver and the instantiating nodes. |

--- a/docs/statescript/resolvers/README.md
+++ b/docs/statescript/resolvers/README.md
@@ -4,6 +4,8 @@ Forge for Godot uses the core Forge resolver set and adds Godot-facing resolver 
 
 Use the **core Forge documentation** for runtime resolver behavior and API details. Use the pages in this folder when Godot authoring adds editor, resource, or binding details.
 
+A second group of resolvers — [the engine-facing ones](#godot-engine-resolvers) — has no core counterpart at all: they read the scene tree, the physics world, cameras, input, navigation and the clock. Their pages here are the canonical reference as well as the authoring notes.
+
 ## Core Resolver Reference
 
 | Category | Core Docs | Notes |
@@ -50,7 +52,7 @@ These pages cover authoring details that the Godot editor adds on top of the cor
 | [SetByCallerMagnitudeResolver](set-by-caller-magnitude-resolver.md) | `float` | Reads the SetByCaller magnitude stored on an `Effect` for a selected tag. |
 | [EventPayloadOutputResolver](event-payload-resolver.md#listener-side-eventpayloadoutputresolver) | `EventPayloadWriter` | Selects an `IEventPayloadProvider` to write a received payload to graph variables for `EventListenerNode`. |
 | [EventPayloadResolver](event-payload-resolver.md#raise-side-eventpayloadresolver) | `EventPayloadRaiser` | Selects an `IEventPayloadProvider` to build and raise a typed event payload for `RaiseEventNode`. |
-| [IsValidResolver](is-valid-resolver.md) | `bool` | Authors a validity (non-null) check over an object-backed variable of any registered type. |
+| [IsValidResolver](is-valid-resolver.md) | `bool` | Authors a validity check over an object-backed variable of any registered type. Rejects null, invalidated handles, and freed Godot objects. |
 | [ObjectEqualsResolver](object-equals-resolver.md) | `bool` | Authors a reference-identity check between two object-backed variables of any registered type. |
 | [OwnershipResolver](ownership-resolver.md) | `EffectOwnership` | Composes effect ownership from two nested entity resolvers. |
 | [TagResolver](tag-resolver.md) | `Tag` | Selects one or more registered tags for any tag input (e.g. the cue nodes). |
@@ -65,7 +67,35 @@ These resolvers add no Godot-specific authoring beyond the standard nested-opera
 
 ### Object Variable Types
 
-Object-backed graph values are keyed by an object variable type. In addition to the built-in `Entity`, `Effect`, and `ActiveEffectHandle` types, this release registers `Tag`, `AbilityHandle`, and `AbilityData` — used by the tag listener output, the grant nodes' handle output and lookup resolvers, and the ability grant inputs respectively.
+Object-backed graph values are keyed by an object variable type. In addition to the built-in `Entity`, `Effect`, and `ActiveEffectHandle` types, Forge for Godot registers:
+
+| Type id | Display name | Backing type | Used by |
+|---------|--------------|--------------|---------|
+| `Tag` | Tag | `Tag` | The tag listener's output. |
+| `AbilityHandle` | Ability Handle | `AbilityHandle` | The grant nodes' handle output and the lookup resolvers. |
+| `AbilityData` | Ability Data | `AbilityData` | The ability grant inputs. |
+| `GodotNode` | Node | `Godot.Node` | Everything in the node lane — spawn outputs, hit nodes, the interop rows. |
+| `Scene` | Scene | `Godot.PackedScene` | The scene `Constant` resolver and the instantiating nodes. |
+| `Shape3D` | Shape 3D | `Godot.Shape3D` | The 3D [shape resolvers](shapes.md) and every 3D query that takes one. |
+| `Shape2D` | Shape 2D | `Godot.Shape2D` | The 2D shape resolvers. Deliberately a separate type — the two physics servers do not mix. |
+
+Because a shape, a scene and a node all travel the object lane, an operand of any of them is a nested picker like any other, and can be seeded with a composed resolver.
+
+
+## Godot Engine Resolvers
+
+These read the engine rather than the Forge simulation, so nothing about them exists in the core library. They are grouped by the authoring model they share; each page carries a table of the individual resolvers with their outputs and rows.
+
+| Guide | Resolvers | What they answer |
+|-------|-----------|------------------|
+| [Spatial Getters](spatial-getters.md) | `Entity Position`, `Entity Direction`, `Entity Rotation`, `Entity Scale`, `Entity Velocity`, `Entity Angular Velocity`, `Entity Transform Point`, `Character State`, `Character Motion`, `Can Fit` | What is true of the node an entity lives on. All 2D/3D pairs, all sharing an entity operand and an optional `%marker` path. |
+| [Physics Query Resolvers](physics-queries.md) | `Area Overlaps`, `Overlap`, `Entities In Cone`, `Entities At Point`, `Closest Entity`, `Is In Cone`, `Line Of Sight`, `Shapecast` | Who is in there, can I see it, what would this sweep meet. `Entity[]` and `bool` results, so they compose with `Where`, `OrderBy` and `Except`. |
+| [Shape Resolvers](shapes.md) | `Sphere`, `Box`, `Capsule`, `Cylinder`, `Cone`, `Circle`, `Rectangle`, `Wedge`, `Constant` | The shape a query sweeps, built from resolvers so every dimension can scale. |
+| [Camera and Aim Resolvers](camera-and-aim.md) | `Camera Position`, `Camera Forward 3D`, `Mouse World Position` | Where the graph's own player is looking and pointing. No entity operand — the viewport the owner stands in answers "whose camera". |
+| [Input Resolvers](input-resolvers.md) | `Input Action Pressed`, `Input Action Strength`, `Input Axis`, `Input Vector 2` | Button and analog state, for expression gates and condition monitors. |
+| [Scene Graph and Interop Resolvers](scene-graph-resolvers.md) | `Constant` (scene and node path), `Node From Entity`, `Entity From Node`, `Entity At Path`, `Node Property`, `Parent Entity`, `Child Entities`, `Nodes In Node Group`, `Entities In Node Group` | Crossing between entities, nodes and scenes, and reading a node's own state. |
+| [Navigation Resolvers](navigation-resolvers.md) | `Nav Reachable`, `Nav Path Length`, `Nav Closest Point` | Whether a walk is possible, how long it is, and where the nearest legal ground is. |
+| [Engine and Timing Resolvers](engine-resolvers.md) | `Delta Time`, `Engine Time`, `Animation Length` | The running tick's step, monotonic time, and how long a clip is. |
 
 ## Authoring Guides
 
@@ -73,9 +103,20 @@ The array-operation resolver family (`Where`, `Order By`, `Take`, `Select`, `Cou
 
 - [Array Operations Authoring](array-operations.md) — nested source, per-element (lambda) operands and element resolvers, iteration scope, and the value/object lanes.
 
+The [Godot engine resolvers](#godot-engine-resolvers) above are grouped the same way and for the same reason.
+
+## Seeding a Nested Operand
+
+A **node input** marked optional renders a `(None)` entry and genuinely stays unbound, which is what lets Raycast read "no mask" as every layer. A nested operand **inside a resolver** has no such state: the picker always selects an editor, and an untouched one is the constant zero.
+
+So any resolver operand whose sensible default is not zero is *seeded* with the resolver that expresses it — `Overlap`'s Position starts on `Entity Position 3D`, its Shape on a Sphere, both ends of `Line Of Sight` on `Entity Position 3D`, `Mouse World Position 3D`'s Max Dist on the same 1000 units the aim payload uses. An untouched row runs what the editor shows.
+
+The same reasoning reaches node inputs whose default is a composed resolver rather than a constant, which is why [Line Of Sight](../nodes/physics-query-nodes.md#line-of-sight)'s Ignore row is required and seeded with an array of the owner and the target rather than being optional.
+
 ## Related Docs
 
 - [Variables and Data](../variables.md)
 - [Statescript Enums](../enums.md)
 - [Custom Resolvers](../custom-resolvers.md)
+- [Physics Debug Drawing](../physics-debug-drawing.md)
 - [Resolver Template](../templates/resolver-template.md)

--- a/docs/statescript/resolvers/camera-and-aim.md
+++ b/docs/statescript/resolvers/camera-and-aim.md
@@ -1,0 +1,53 @@
+# Camera and Aim Resolvers
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers`
+>
+> **Runtime:** `Gamesmiths.Forge.Godot.Core.Statescript.Resolvers`
+
+These resolvers are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They answer "where is the player looking, and where is the player pointing".
+
+| Resolver | Output | Settings and operands |
+|---|---|---|
+| **Camera Position 3D** | `Vector3` | — |
+| **Camera Position 2D** | `Vector2` | — |
+| **Camera Forward 3D** *(unpaired)* | `Vector3` | — |
+| **Mouse World Position 3D** | `Vector3` | **Mode** (`PhysicsRay`/`PlaneIntersect`); Mask; Max Dist |
+| **Mouse World Position 2D** | `Vector2` | — |
+
+`Camera Forward 3D` is shooter centre-aim, and has no 2D twin because a 2D camera has no forward.
+
+## These take no entity operand
+
+A camera is not something an entity *has* — it is how the graph's own player sees, which is a property of the ability being run. So "whose camera" is answered the same way "which physics world" already is: **the viewport the ability's owner is standing in**. Split screen therefore works without authoring anything, since each player's graph reads its own half.
+
+That is also why they are not prefixed `Entity`, unlike the [spatial getters](spatial-getters.md#named-for-what-they-read-from).
+
+## Mouse World Position 3D
+
+| Mode | Behavior |
+|---|---|
+| `PhysicsRay` | Casts from the cursor into the world and reports what it meets. **Mask** and **Max Dist** apply. |
+| `PlaneIntersect` | Intersects the cursor ray with the horizontal plane through the caster. Nothing is queried. |
+
+**The mask row is hidden in Plane Intersect mode** rather than left fillable and ignored — the same rule the node editors apply through `IsSettingVisible`. The hidden row keeps its value for when the mode comes back.
+
+**Max Dist starts on a constant rather than at zero.** A nested operand has no unbound state, so an untouched distance would be zero and every query would resolve onto the camera itself; the row is seeded with the 1000 units [`AimActivationData`](../nodes/custom-nodes.md#built-in-activation-data-providers) already uses.
+
+## Mouse World Position 2D takes no settings at all
+
+**And it is not a camera resolver**, which is the part worth writing down. A 2D cursor already names a point on the plane the game is played on, so undoing the viewport's canvas transform *is* the answer: there is no mode to pick between, no ray to mask, and no reach to limit.
+
+It reads through the owner's own node rather than through a camera, because a 2D game without a `Camera2D` still has a viewport with a canvas transform, and a resolver that demanded a camera would report nothing for the games that never add one. `Camera Position 2D` does require one, because the centre of the view is genuinely a thing only a camera has.
+
+## Aim as a payload
+
+Sampling aim *once*, at activation, is usually better than polling — it is required for authoritative or networked games, and it is what lets a sub-ability be activated with the aim the parent resolved. [`AimActivationData` and `AimActivationData2D`](../nodes/custom-nodes.md#built-in-activation-data-providers) are the standard payload for that, with `FromCamera`/`FromMouseGround` in 3D and `FromMouse`/`FromFacing` in 2D.
+
+## Related Docs
+
+- [Resolvers Reference](README.md)
+- [Input Resolvers](input-resolvers.md)
+- [InputActionNode](../nodes/input-action-node.md)
+- [Custom Nodes](../nodes/custom-nodes.md#built-in-activation-data-providers) — the aim payloads and their providers

--- a/docs/statescript/resolvers/engine-resolvers.md
+++ b/docs/statescript/resolvers/engine-resolvers.md
@@ -1,0 +1,41 @@
+# Engine and Timing Resolvers
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers`
+>
+> **Runtime:** `Gamesmiths.Forge.Godot.Core.Statescript.Resolvers`
+
+These resolvers are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They read the engine itself rather than the scene: the running tick, the clock, and how long an animation is.
+
+| Resolver | Output | Rows |
+|---|---|---|
+| **Delta Time** | `double` | — |
+| **Engine Time** | `double` | — |
+| **Animation Length** | `float` | Of (entity); **Player** (path); **Animation** (name) |
+
+## Delta Time
+
+The step of the tick currently running. It matters because a graph has [two rails](../README.md#in-godot) with different deltas.
+
+**It has no Frame-or-Fixed switch, deliberately.** The author already knows which rail their node runs on, so a switch would only ever be set to agree with it — and set wrong it reports a plausible number from the other clock, which is the worst kind of bug to look at. `Engine.IsInPhysicsFrame()` answers it instead, so one resolver reads correctly from either rail.
+
+This is the one place a resolver *can* tell which rail is walking it. `GraphContext.UpdateStamp` cannot, because it counts passes over both and has no engine call to fall back on.
+
+## Engine Time
+
+Monotonic engine time, for timestamping. Two stamps always subtract to a real interval.
+
+## Animation Length
+
+Feeds timer durations so a windup stays in sync with the art.
+
+**It reads the clip, not the playback**, which is what lets it be answered at activation before anything is playing — the whole point, since a timer fed from here cannot drift from the animation it is pacing. The **Player** path follows the same rule as the [presentation nodes](../nodes/presentation-nodes.md#the-player-path): empty means the entity's first animation player child.
+
+It does not divide by playback speed, because a clip does not know what speed it will be played at. A graph that also drives the speed divides itself.
+
+## Related Docs
+
+- [Resolvers Reference](README.md)
+- [Presentation Nodes](../nodes/presentation-nodes.md)
+- [Statescript](../README.md#in-godot) — the frame and fixed rails

--- a/docs/statescript/resolvers/engine-resolvers.md
+++ b/docs/statescript/resolvers/engine-resolvers.md
@@ -12,7 +12,7 @@ They read the engine itself rather than the scene: the running tick, the clock, 
 |---|---|---|
 | **Delta Time** | `double` | — |
 | **Engine Time** | `double` | — |
-| **Animation Length** | `float` | Of (entity); **Player** (path); **Animation** (name) |
+| **Animation Length** | `double` | Of (entity); **Player** (path); **Animation** (name) |
 
 ## Delta Time
 

--- a/docs/statescript/resolvers/input-resolvers.md
+++ b/docs/statescript/resolvers/input-resolvers.md
@@ -17,7 +17,7 @@ All four are unpaired — a button has no dimension.
 | **Input Axis** | `float` | **Negative**; **Positive** |
 | **Input Vector 2** | `Vector2` | **Left**; **Right**; **Up**; **Down** |
 
-**`Input Axis` is not a subtraction of two strengths.** The two actions *cancel*, which is what a subtraction does not do — holding both leaves the axis at zero rather than at whichever analog value happens to be larger.
+**`Input Axis` is Godot's `Input.GetAxis`**: the positive action's strength minus the negative one's. Holding both cancels to zero when they are equally strong, and otherwise reports the difference, so the stronger side wins by how much it leads. That is one row instead of two strengths and a `Subtract`, and it keeps the operand order — negative first — the same as the engine's.
 
 `Input Vector 2` gives movement-direction aiming without a camera.
 

--- a/docs/statescript/resolvers/input-resolvers.md
+++ b/docs/statescript/resolvers/input-resolvers.md
@@ -1,0 +1,38 @@
+# Input Resolvers
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers`
+>
+> **Runtime:** `Gamesmiths.Forge.Godot.Core.Statescript.Resolvers`
+
+These resolvers are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They read Godot input actions as values, for `ExpressionNode` gates, `ConditionMonitorNode` conditions, and any numeric or vector input. Waiting on a button is the [`InputActionNode`](../nodes/input-action-node.md) instead.
+
+All four are unpaired — a button has no dimension.
+
+| Resolver | Output | Rows |
+|---|---|---|
+| **Input Action Pressed** | `bool` | **Action**; **Mode** (`Pressed`, `JustPressed`, `JustReleased`) |
+| **Input Action Strength** | `float` | **Action** | 
+| **Input Axis** | `float` | **Negative**; **Positive** |
+| **Input Vector 2** | `Vector2` | **Left**; **Right**; **Up**; **Down** |
+
+**`Input Axis` is not a subtraction of two strengths.** The two actions *cancel*, which is what a subtraction does not do — holding both leaves the axis at zero rather than at whichever analog value happens to be larger.
+
+`Input Vector 2` gives movement-direction aiming without a camera.
+
+## The action field
+
+The same control serves these four and the [node's Action setting](../nodes/input-action-node.md#the-action-field): free text, with a dropdown of the project's actions beside it, and an editor warning colour on a name the project does not define.
+
+It stays free text because the project's list is a *subset* of what the runtime accepts — Godot's `ui_*` presets are valid and deliberately hidden, and a game may register actions from code — so a dropdown would be authoritative about something it is not. A resolver editor rebuilds its resource from its controls on every save, so a dropdown would also silently rewrite a stored name the next time anything in the node was touched.
+
+## Input is client-local
+
+These read the local machine's input state. Authoritative or networked games should sample aim and button state once at activation into [`AimActivationData`](../nodes/custom-nodes.md#built-in-activation-data-providers) rather than polling them inside a server-side graph.
+
+## Related Docs
+
+- [Resolvers Reference](README.md)
+- [InputActionNode](../nodes/input-action-node.md)
+- [Camera and Aim Resolvers](camera-and-aim.md)

--- a/docs/statescript/resolvers/is-valid-resolver.md
+++ b/docs/statescript/resolvers/is-valid-resolver.md
@@ -4,17 +4,27 @@
 >
 > **Output Type:** `bool`
 
-Authors a validity (non-null) check over an object-backed variable for condition inputs. Works with any registered object variable type: entities, effects, active effect handles, and game-registered types.
+Authors a validity check over an object-backed variable for condition inputs. Works with any registered object variable type: entities, effects, active effect handles, nodes, scenes, shapes, and game-registered types.
 
 ## Authoring in Godot
 
 - Opens with a **Type** dropdown listing the registered object variable types. The **Source** picker below it offers the resolvers compatible with that type (for entities: owner/source/target, variables, and entity array accessors; for other types: object variables, plus the element resolver inside an array operation's per-element operand).
-- Returns `true` when the source resolves to a non-null value, e.g. "is the stored active effect still set?".
+- Returns `true` when the source resolves to a value that still refers to something, e.g. "is the stored active effect still set?".
 - There is no negate option: for an "is null" check wrap it in a `Not` resolver, or when driving an `ExpressionNode` connect the `false` port.
+
+## What counts as invalid
+
+Three things, and the third is the Godot half:
+
+1. **Null.**
+2. **A value that has stopped referring to anything.** Several core types stay non-null after they stop meaning anything — an `ActiveEffectHandle` whose effect was removed, an `AbilityHandle` whose ability was revoked, an empty `Tag`. They report themselves through core's `IValidatable`, so the resolver calls them invalid rather than merely non-null.
+3. **A freed `GodotObject`.** A node a graph spawned and something else queued for deletion is a live C# reference to a dead engine object.
+
+The third check is what the Godot layer adds. Core's `IsValid` is virtual precisely so this can be a subclass rather than a second, competing resolver — **one validity question in the editor, not two that each answer half of it.**
 
 ## Runtime Binding
 
-At graph-build time the resource builds its source through `TryBuildObjectResolver` and wraps it in the core `IsValidResolver`. A missing source, or one that does not produce an object-backed value, reports an editor error and the check resolves to a constant `false`. The selected type is editor metadata only; the runtime works on whatever the source produces.
+At graph-build time the resource builds its source through `TryBuildObjectResolver` and wraps it in `GodotIsValidResolver`, which extends the core `IsValidResolver` with the freed-object check. A missing source, or one that does not produce an object-backed value, reports an editor error and the check resolves to a constant `false`. The selected type is editor metadata only; the runtime works on whatever the source produces.
 
 ## Related Docs
 

--- a/docs/statescript/resolvers/navigation-resolvers.md
+++ b/docs/statescript/resolvers/navigation-resolvers.md
@@ -1,0 +1,39 @@
+# Navigation Resolvers
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers`
+>
+> **Runtime:** `Gamesmiths.Forge.Godot.Core.Statescript.Resolvers`
+
+These resolvers are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They make navigation *askable* as well as walkable: [`Nav Move To`](../nodes/navigation-nodes.md) walks, and these three answer questions about the walk before it starts. Without them an AI graph cannot branch on reachability, and a blink to the cursor cannot be made to land somewhere legal.
+
+Each is a 2D/3D pair, because `NavigationServer2D` and `NavigationServer3D` are two APIs with different vector types.
+
+| Resolver | Output | Operands |
+|---|---|---|
+| **Nav Reachable 3D** | `bool` | From; To; **Within** (tolerance) |
+| **Nav Path Length 3D** | `double` | From; To |
+| **Nav Closest Point 3D** | `Vector3` | **Of** (point) |
+
+## Reachable is not "a path came back"
+
+`NavigationServer.MapGetPath` answers an impossible request with a perfectly good path to the closest point it could reach, so a destination across a chasm returns a full path that simply stops at the edge. The test is whether the path's **last point lands near the one asked for**, which is what the **Within** row is.
+
+The tolerance has to be forgiving, because the destination is snapped onto the navigation mesh before the path is built — even an obviously reachable point rarely comes back exactly. The unbound default is `NavigationAgent`'s own `target_desired_distance`: **1.0 in 3D, 10.0 in 2D**, so a check agrees with what an agent walking the same path would report rather than inventing a second standard.
+
+## Path length reports the walk it can make
+
+`Nav Path Length` measures the walk to the **closest reachable point** and does not fail — the honest reading of "how far can I get". That means zero is ambiguous: already there, and no path at all, read the same.
+
+That is the same conflation Godot's own API makes, and the answer is composition — ask `Nav Reachable` first when the difference matters — rather than a second return channel a resolver has no way to express.
+
+## Nav Closest Point
+
+Clamps a point onto walkable floor, which is what makes a ground-targeted blink or a cursor-aimed summon land somewhere legal.
+
+## Related Docs
+
+- [Resolvers Reference](README.md)
+- [Navigation Nodes](../nodes/navigation-nodes.md) — `Nav Move To`
+- [Spatial Getters](spatial-getters.md) — `Can Fit`, the physics counterpart to a legality check

--- a/docs/statescript/resolvers/navigation-resolvers.md
+++ b/docs/statescript/resolvers/navigation-resolvers.md
@@ -20,7 +20,7 @@ Each is a 2D/3D pair, because `NavigationServer2D` and `NavigationServer3D` are 
 
 `NavigationServer.MapGetPath` answers an impossible request with a perfectly good path to the closest point it could reach, so a destination across a chasm returns a full path that simply stops at the edge. The test is whether the path's **last point lands near the one asked for**, which is what the **Within** row is.
 
-The tolerance has to be forgiving, because the destination is snapped onto the navigation mesh before the path is built — even an obviously reachable point rarely comes back exactly. The unbound default is `NavigationAgent`'s own `target_desired_distance`: **1.0 in 3D, 10.0 in 2D**, so a check agrees with what an agent walking the same path would report rather than inventing a second standard.
+The tolerance has to be forgiving, because the destination is snapped onto the navigation mesh before the path is built — even an obviously reachable point rarely comes back exactly. A fresh **Within** row is seeded with `NavigationAgent`'s own `target_desired_distance` — **1.0 in 3D, 10.0 in 2D** — so a check agrees with what an agent walking the same path would report rather than inventing a second standard, and what the editor shows is what runs.
 
 ## Path length reports the walk it can make
 

--- a/docs/statescript/resolvers/physics-queries.md
+++ b/docs/statescript/resolvers/physics-queries.md
@@ -1,0 +1,73 @@
+# Physics Query Resolvers
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers`
+>
+> **Runtime:** `Gamesmiths.Forge.Godot.Core.Statescript.Resolvers`
+
+These resolvers are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They ask the physics world a question and hand back a value, so they compose: an `Entity[]` feeds `ForEach`, `Where`, `OrderBy` and `Except`, and a `bool` works inside a `Where` lambda. Queries whose answer is several values at once — a hit position *and* a normal *and* a distance — are [nodes](../nodes/physics-query-nodes.md) instead, so one query writes them all atomically.
+
+Every one is a 2D/3D pair.
+
+## Shared operands
+
+- **Mask** (`int`, nested). **Zero means every layer.** A mask of zero can never find anything, so it is never a useful authored value, and reading it literally would make an untouched row silently disable the query.
+- **Ignore** (`Entity[]`, nested, seeded with the ability's owner). What the query keeps off. It is a *list* because both ends of a query sit inside a body: a ray from a character's own position starts at its feet, outside its own capsule by a hair, and a line drawn to a marker on a target ends inside the target. Being a list also means an overlap's results can be fed straight in, for a check that should pass through a whole group.
+- **Include Areas** (checkbox) where the query can meet one.
+
+**A nested operand has no unbound state**, so every operand whose sensible default is not zero is *seeded* with the resolver that expresses it — Overlap's Position starts on `Entity Position 3D`, its Shape on a Sphere, both ends of Line Of Sight on `Entity Position 3D`, Shapecast's Origin and Direction on the owner's position and forward. An untouched row runs what the editor shows.
+
+## Entity-list queries
+
+| Resolver | Output | Operands | Notes |
+|---|---|---|---|
+| **Area Overlaps 3D** | `Entity[]` | Of (entity); **Area** (path); Ignore | Reads an existing `Area3D`'s overlaps. The entity plus the path names *whose* area. |
+| **Overlap 3D** | `Entity[]` | Shape; Position; Rotation; Mask; Ignore | A transient query. **No entity operand** — Position says where, Ignore says who is left out. |
+| **Entities In Cone 3D** | `Entity[]` | Origin; Direction; Range; **Angle (deg)**; Mask; Ignore | Earns a slot because the composed form is five or more resolvers deep. |
+| **Entities At Point 3D** | `Entity[]` | Position; Mask; Ignore | `IntersectPoint` — the one query with no shape behind it. |
+
+**`Entities At Point` is not an overlap with a small sphere.** A sphere needs a radius, and that radius is the whole difference between "standing exactly here" and "standing near here". What occupies a tile, whether a spawn point is free; in 2D, the picking query.
+
+## Narrowing and testing
+
+| Resolver | Output | Operands | Notes |
+|---|---|---|---|
+| **Closest Entity 3D** | `Entity` | **Entities**; **Position** (seeded with the owner's position) | Runs no query of its own — it narrows a group something else found. |
+| **Is In Cone 3D** | `bool` | Point; Origin; Direction; **Angle (deg)**; Range | The angle test on its own, so it composes in a `Where` over any entity array. Range is optional: zero means unlimited. |
+| **Line Of Sight 3D** | `bool` | From; To; Ignore; Mask | Between two **points**, not two entities. |
+| **Shapecast 3D** | `Entity` | Shape; Origin; Direction; Max Dist; Rotation; Mask; Ignore | Swept cast, first hit: a ray with the width of the thing being checked. |
+
+**`Closest Entity` is the chain-lightning primitive**: overlap, then closest, then core's `Except` over what has already been struck, repeated. Running no query is exactly what makes it compose.
+
+**Line Of Sight takes points rather than entities** because an entity's position is an [`Entity Position 3D`](spatial-getters.md) away, and points also cover a sight check to where the player clicked or to a predicted intercept, which have no entity to name. Both ends are seeded with `Entity Position 3D`, and its Ignore row with the owner **and** the target, since both ends of a line usually sit inside a body.
+
+**`Is In Cone` and `Entities In Cone` share one test.** The angle check was originally locked inside the query, which broke the layer's own rule that a shortcut ships *beside* its parts: a cone filter could not be applied to an area's overlaps, a child list or a variable. Sharing the test also means a filter can never disagree with the query it mirrors.
+
+## The cone is a sphere plus a filter
+
+Godot has no cone collision shape and no physics-server call that takes one, so `Entities In Cone` sweeps the sphere the aperture is inscribed in and tests each result by angle. Two things follow: **the range is the cone's slant reach** rather than its depth, because that is what a sphere radius is; and the cone exists only for the instant it is tested, which is why it cannot be swept by a Shapecast or held by an [Overlap node](../nodes/physics-query-nodes.md#overlap).
+
+When you need a cone that *is* a shape, [`Cone`](shapes.md#the-cone-and-the-wedge) builds a convex hull. The two do not agree at the edges, and the difference is documented there.
+
+## An aperture is in degrees
+
+**It is the only angle in the layer that is.** Every other angle here is a rotation — it gets lerped, wrapped, read off a transform or handed to a quaternion, and core's numeric toolbox speaks radians throughout. An aperture is none of those: it is a design figure typed once and never computed, and radians would put a `DegToRad` in front of every cone in the game to say what `90` already says. The row is labelled `Angle (deg)` so the exception is visible where it is authored.
+
+**The authored figure is the whole aperture** and is halved internally, because a 90-degree cleave means 45 degrees either side of the facing everywhere that phrase is used.
+
+## What a resolver cannot return
+
+`Shapecast` computes a hit position, a normal, a collider and a distance and can hand back only one of them — that is what a resolver *is*. When the rest matter, use the [`Shapecast` Condition node and the `Sweep` State node](../nodes/physics-query-nodes.md), which write all five outputs in the same order and with the same names the ray nodes use.
+
+## What differs in 2D
+
+The whole family mirrors, with `Overlap 2D`'s and `Shapecast 2D`'s rotation operands being angles in radians rather than quaternions, and the cone being a wedge. Line Of Sight, Area Overlaps, Closest Entity, Is In Cone and Entities At Point differ only in vector type.
+
+## Related Docs
+
+- [Resolvers Reference](README.md)
+- [Physics Query Nodes](../nodes/physics-query-nodes.md) — the compound-result and monitored forms
+- [Shape Resolvers](shapes.md)
+- [Spatial Getters](spatial-getters.md) — `Can Fit`, and what feeds a Position operand
+- [Physics Debug Drawing](../physics-debug-drawing.md)

--- a/docs/statescript/resolvers/scene-graph-resolvers.md
+++ b/docs/statescript/resolvers/scene-graph-resolvers.md
@@ -1,0 +1,86 @@
+# Scene Graph and Interop Resolvers
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers`
+>
+> **Runtime:** `Gamesmiths.Forge.Godot.Core.Statescript.Resolvers`
+
+These resolvers are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They move between the three things a Godot graph deals in — an entity, a scene node, and a `PackedScene` — and read a node's own state. All of them are dimension-neutral.
+
+## Scenes and nodes as values
+
+| Resolver | Output | Rows |
+|---|---|---|
+| **Constant** (scene) | `PackedScene` (object type `Scene`) | An exported `PackedScene`, scalar or array |
+| **Constant** (node path) | `Node` (object type `GodotNode`) | A **Node Path** string |
+
+The scene picker is the only way a `.tscn` reaches a graph, since node settings carry primitives only. It feeds [`Instantiate Scene`](../nodes/scene-nodes.md#the-instantiating-pair) and `Scene`.
+
+The node path resolver is the node lane's constant, so a hand-placed container or marker is reachable without a variable something else had to write. Absolute paths and `%` unique names are supported, and a `%name` is resolved **outward from the graph's own entity** rather than down from the current scene — see [node paths](../nodes/spatial-nodes.md#node-paths).
+
+## Crossing between lanes
+
+| Resolver | Output | Rows | Notes |
+|---|---|---|---|
+| **Node From Entity** | `Node` | Of (entity); **Node** (path) | The entity's nearest spatial ancestor of *either* kind. |
+| **Entity From Node** | `Entity` | **Node** (nested) | What a spawn wrote to a variable, or a ray reported as its collider, becomes something effects can be applied to. |
+| **Entity At Path** | `Entity` | **Node Path** | `Entity From Node` over a node path in one row. |
+
+`Node From Entity` resolves through the bridge's `TryGetOwningNode`, the same lookup the [interop nodes](../nodes/interop-nodes.md#the-node-row) use for their unbound Node row, so the two cannot drift. **A path that misses resolves to null rather than falling back**, because the path names *which* node is wanted — unlike the [spatial getters](spatial-getters.md#shared-rows), where the path is an offset from a subject that is already known.
+
+**`Entity At Path` is a deliberate exception to the "cut as already composable" rule.** It is exactly `Entity From Node` over a node path and should by that rule have been cut. It ships anyway because naming a character already in the level is common enough that two nested pickers every time is friction rather than composition. The test is not "can this be composed" but "is it composed often enough that the composition becomes the thing" — and when the answer is yes, the shortcut ships **beside** the parts, never instead of them.
+
+## Reading a node's own state
+
+**Node Property** is the read escape hatch, and the counterpart to [`Set Node Property`](../nodes/interop-nodes.md#properties).
+
+| Row | Meaning |
+|---|---|
+| **Node** | Nested, seeded with `Node From Entity`, so a fresh one reads "a property on me". |
+| **Property** | The property path. |
+| **Type** | One of the [interop conversion set](../nodes/interop-nodes.md#the-conversion-set), seeded from the slot's own expected type. |
+
+**There is no array checkbox.** A resolver is handed the shape of the slot it sits in, so the same Node Property reads an array in an array input and a value in a scalar one, and the resource records what it was told rather than what anyone authored. The type row is seeded the same way, which leaves a choice to make only in the wildcard operands — the sides of a comparison, a math operand — where the slot genuinely does not say.
+
+**A bad property path is reported, not guessed at.** `GetIndexed` answers an unknown path with nothing at all, so the read checks that the object declares the path's first segment — but only when the value comes back nil, since a resolver runs every tick. For a value-lane read nil is already impossible from a declared property, and for the object lane an unset reference is a legitimate answer that costs one scan to confirm.
+
+## Entity hierarchy
+
+| Resolver | Output | Rows |
+|---|---|---|
+| **Parent Entity** | `Entity` | Of (entity) |
+| **Child Entities** | `Entity[]` | Of (entity) |
+
+Projectile-sub-entity to caster patterns, and the summoner acting on everything it summoned.
+
+**Both step over the levels that resolve back to the entity being read.** Under the composition pattern an entity's node is a *child* of its body, so the body is a level whose children include the entity itself — `Parent Entity` climbing one level and asking "is there an entity here" would get itself back and report everything as its own parent.
+
+`Child Entities` also **stops descending at each entity it finds**, because what is inside a turret belongs to the turret: a builder asking for its children should not be handed its turrets' passengers, and one more `Child Entities` on the turret is how those are reached.
+
+## Godot groups
+
+A Godot group is a name attached to scene nodes, and it is the one way to reach a set assembled by hand across a level — every spawn point, every cover marker, a whole patrol, none of which a path or a hierarchy walk can name.
+
+| Resolver | Output | Row |
+|---|---|---|
+| **Nodes In Node Group** | `Node[]` | **Group** |
+| **Entities In Node Group** | `Entity[]` | **Group** |
+
+**`Entities In Node Group` returns a set, not a list.** A project that puts both a body and its hurtbox in one group has named two nodes and one entity, and a `ForEach` over the result would apply everything to it twice. `Nodes In Node Group` has no such problem and returns them as they come.
+
+Writing to a group is the [group nodes](../nodes/scene-nodes.md#godot-groups): `Add To Node Group`, `Remove From Node Group`, and `Node Group` for a membership that lasts exactly as long as an ability.
+
+The family is named for what a group *is* rather than for what a node does to one. `Group Override` would have described nothing, and plain "Group" invites a reader arriving from the tags or effects side to assume a Forge concept. `NodeGroup` carries the Godot meaning in the name, at the cost of a class called `NodeGroupNode` and a resolver called `Nodes In Node Group` — the price of a family whose names all say the same word.
+
+## Is Valid, extended
+
+The Godot layer subclasses core's `IsValidResolver` so one validity question in the editor is not two that each answer half of it. See [IsValidResolver](is-valid-resolver.md).
+
+## Related Docs
+
+- [Resolvers Reference](README.md)
+- [Interop Nodes](../nodes/interop-nodes.md) — the writing half
+- [Scene Nodes](../nodes/scene-nodes.md) — spawning, freeing, reparenting, groups
+- [Spatial Getters](spatial-getters.md)
+- [Variables and Data](../variables.md) — object variable types

--- a/docs/statescript/resolvers/shapes.md
+++ b/docs/statescript/resolvers/shapes.md
@@ -1,0 +1,67 @@
+# Shape Resolvers
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers`
+>
+> **Output Types:** `Godot.Shape3D` (object variable type `Shape3D`) and `Godot.Shape2D` (`Shape2D`)
+
+These resolvers are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They build the shape a physics query sweeps. Every dimension is a nested resolver, so a radius can scale with an attribute, a level or a variable.
+
+## A shape is a value
+
+The alternative was an enum setting plus fixed numeric inputs, or an exported `Shape3D` — and a radius that cannot scale with an attribute is not much use. Building shapes the way scenes and nodes are built, as an object variable type plus a resolver family, gives both: a shape can live in a variable, be built once on entry and swept by every tick of a loop, or be chosen by a `Conditional` resolver.
+
+**Each shape names its own dimensions**, which one fixed set of inputs could not: a capsule takes a radius and a *height*, not an extents vector.
+
+**Placement belongs to the query, not the shape.** A `Shape3D` has no transform of its own, so the [Overlap](../nodes/physics-query-nodes.md#overlap) and [Shapecast](../nodes/physics-query-nodes.md#shapecast) rows carry Position and Rotation — which is what lets a box or a capsule be turned.
+
+## 3D shapes
+
+| Picker entry | Operands | Notes |
+|---|---|---|
+| **Sphere** | Radius | |
+| **Box** | Size | Full size, matching Godot's `BoxShape3D.Size`. |
+| **Capsule** | Radius; Height | Total height, caps included, clamped to at least twice the radius. |
+| **Cylinder** | Radius; Height | Total height. |
+| **Cone** | Angle (deg); Range | A convex hull — see [below](#the-cone-and-the-wedge). |
+| **Constant** | an exported `Shape3D` | For a convex hull, a height map, or a primitive whose size never changes. |
+
+## 2D shapes
+
+| Picker entry | Operands | Notes |
+|---|---|---|
+| **Circle** | Radius | The 2D answer to both the sphere and the cylinder. |
+| **Rectangle** | Size | Full size, matching Godot's `RectangleShape2D.Size`. |
+| **Capsule** | Radius; Height | As the 3D capsule. |
+| **Wedge** | Angle (deg); Range | A plane's cone, and a genuinely simpler shape. |
+| **Constant** | an exported `Shape2D` | For a convex polygon, or a primitive whose size never changes. |
+
+## The cone and the wedge
+
+Godot has no cone collision shape, so `Cone` builds the convex hull of an apex and a ring on the rim. That *is* a `Shape3D` and goes anywhere a shape goes — swept by a Shapecast, held by an Overlap node.
+
+**It does not agree with [`Entities In Cone`](physics-queries.md#the-cone-is-a-sphere-plus-a-filter) at the edges.** The hull's facets are chords of the rim circle, so they sit **inside** the true cone, and a target near the rim between two facets is found by the analytic query and missed by the hull. Both ship, because "cone" turns out to be two different requests: *test* this cone, and *sweep* this cone.
+
+**Both point where a character faces**, not where Godot's primitives point. Godot's cylinder and capsule are Y-up; a gameplay cone is aimed along a facing, so the hulls are built along −Z in 3D and +X in 2D. Binding a query's Rotation to [`Entity Rotation 3D`](spatial-getters.md) aims one correctly with nothing composed in between, and the apex sits at the shape's own origin so binding Position to the caster puts the point of the cone on the caster.
+
+The aperture is clamped just below a half turn in both, because a hull cannot express a reflex cone: past that the rim runs away and the hull closes around behind its own apex. The wedge needs only its two edges and an arc, which is the rare case where the 2D twin is genuinely simpler rather than merely flatter.
+
+## What is deliberately absent
+
+**Every Godot shape with numbers worth authoring has a resolver.** What is left is reached through **Constant** and has nothing to parameterise: the polygon and heightmap shapes are authored geometry rather than dimensions, `SeparationRayShape` is a character-controller foot ray, and `WorldBoundaryShape` is an infinite half-space that would match half the world. `SegmentShape2D` is parametric but is a raycast by another name, and has no 3D twin to pair with.
+
+**The notable shape that is not expressible is the ring.** A donut area of effect is not convex, so no hull can describe it: `Overlap` of the outer radius with core's `Except` over the inner one is how that is composed.
+
+## Two dimensions, two types
+
+Shapes are the one place the pairs do not line up name for name — 2D has no cylinder, and its circle is what both the sphere and the cylinder are used for.
+
+`Shape2D` is a **separate object variable type** from `Shape3D` rather than one shared "shape", because the two physics servers do not mix. Handing a 2D query a 3D shape is not a narrower answer, it is no answer at all, and a dropdown that can express the mistake is a dropdown that will.
+
+## Related Docs
+
+- [Resolvers Reference](README.md)
+- [Physics Query Resolvers](physics-queries.md)
+- [Physics Query Nodes](../nodes/physics-query-nodes.md)
+- [Variables and Data](../variables.md) — object variable types

--- a/docs/statescript/resolvers/spatial-getters.md
+++ b/docs/statescript/resolvers/spatial-getters.md
@@ -1,0 +1,72 @@
+# Spatial Getters
+
+> **Namespace:** `Gamesmiths.Forge.Godot.Resources.Statescript.Resolvers`
+>
+> **Runtime:** `Gamesmiths.Forge.Godot.Core.Statescript.Resolvers`
+
+These resolvers are **Godot-only** — there is no core Forge counterpart, so this page is their reference rather than a Godot-authoring supplement to one.
+
+They read something off the scene node an entity lives on. Every one is a 2D/3D pair, and they share one authoring model, which is why they are documented together: the base carries the two operands they all have, and each resolver adds only its own setting.
+
+## Named for what they read from
+
+A dropdown offering `Position 3D` beside a dozen other sources of a `Vector3` says nothing about where the number comes from. `Entity Position 3D` says it reads a position *off an entity*, which is the part that decides whether it is the resolver you want — and the prefix groups the family together alphabetically in the picker, which is where they are actually chosen from.
+
+## Shared rows
+
+| Row | Meaning |
+|---|---|
+| **Of** | A nested entity picker. Defaults to the ability's **owner**, and accepts anything that produces an entity — including composed sources like [`Entity At Path`](scene-graph-resolvers.md#crossing-between-lanes), the first result of a query, or a `Conditional`. |
+| **Node** | An optional path to a descendant to read instead of the entity's own spatial node. Scene-unique names work, so `%CastPoint` or `%Muzzle` pointed at a marker is how an authored offset is expressed without any code. |
+
+**A missing marker falls back to the entity's own node**, and warns once naming the path. A `%CastPoint` path is an offset from the entity, not a different subject, so an entity authored without the marker still has a right answer: its body. Without the fallback, one graph run against a character with a marker and a plain prop without one would resolve the second to the world origin, and a line of sight aimed at a markerless target would read as a physics bug rather than a missing node.
+
+A `%name` is searched **outward from the graph's entity**, innermost scene first, rather than down from the current scene — see [node paths](../nodes/spatial-nodes.md#node-paths).
+
+## The transform readers
+
+| Resolver | Output | Setting | Notes |
+|---|---|---|---|
+| **Entity Position 3D** | `Vector3` | **Space** (`Global`/`Local`) | |
+| **Entity Direction 3D** | `Vector3` | **Axis** (`Forward`, `Back`, `Right`, `Left`, `Up`, `Down`) | Read off the basis. Godot forward is −Z. |
+| **Entity Rotation 3D** | `Quaternion` | **Space** | |
+| **Entity Scale 3D** | `Vector3` | **Space** | |
+| **Entity Transform Point 3D** | `Vector3` | **Offset** (nested); **Inverse** | Local offset to world point, or back. The generic offset primitive, which is why no cast-point concept enters the engine layer. |
+
+## The physics readers
+
+| Resolver | Output | Setting | Notes |
+|---|---|---|---|
+| **Entity Velocity 3D** | `Vector3` | — | The velocity the game *asked* for. Compare Character Motion's `RealVelocity`, which is what the slide achieved. |
+| **Entity Angular Velocity 3D** | `Vector3` | — | An axis with the rate as its length, so core's `Length` is the spin rate and `Normalize` the axis. `RigidBody` only. |
+| **Can Fit 3D** | `bool` | **Destination** (nested, seeded with the entity's own position) | `TestMove` with no motion: would this body fit *there*. |
+
+**Can Fit tests the body's own shapes**, which is why a [Shapecast](physics-queries.md#narrowing-and-testing) is not a substitute — a sweep can only test a shape somebody authored into the graph, and keeping that in sync with the character it stands for goes stale the first time an artist resizes a capsule. It also asks about the destination rather than the path: a blink is *meant* to skip what is in between, and Shapecast is already the resolver for the journey.
+
+It is the guard the non-solving [Move To](../nodes/spatial-nodes.md#move-to) and [Set Position](../nodes/spatial-nodes.md#instant-writers-action) create a need for — a blink into a wall is the classic way an ability breaks a level.
+
+## The character readers
+
+`CharacterBody` exposes its contact state as **methods**, so [`Node Property`](scene-graph-resolvers.md#reading-a-nodes-own-state) cannot read them and [`Call Method`](../nodes/interop-nodes.md#methods-and-signals) is an Action that cannot appear where a condition is wanted. Without these two, a grounded-only ability, an air-only ability and a wall-jump are unauthorable without code. Two resolvers with an enum each cover thirteen methods without thirteen entries in the picker.
+
+| Resolver | Output | Setting |
+|---|---|---|
+| **Character State 3D** | `bool` | **State**: `OnFloor`, `OnFloorOnly`, `OnWall`, `OnWallOnly`, `OnCeiling`, `OnCeilingOnly` |
+| **Character Motion 3D** | `Vector3` | **Value**: `RealVelocity`, `FloorNormal`, `WallNormal`, `LastMotion`, `PositionDelta`, `PlatformVelocity` |
+
+The `Only` variants are not redundant: a character wedged in a corner is on the floor and on a wall at once.
+
+`RealVelocity` is worth calling out — `Entity Velocity` reads the velocity the game *asked* for, which for a character walking into a wall is a full-speed vector into geometry it never moved through. Wall-jump direction is `WallNormal`; impact damage is `RealVelocity`. **The two normals report zero when the contact does not hold**, rather than the stale one Godot keeps.
+
+## What differs in 2D
+
+- **`Entity Rotation 2D` reports a `float` in radians** rather than a quaternion, so core's whole numeric toolbox applies to a facing directly. **`Entity Angular Velocity 2D`** is likewise a `float` rate rather than an axis.
+- **`Entity Direction 2D` offers four axes, not six.** A plane has no up and down of its own, and screen-up is already `Left` or `Right` of a facing, so it takes a `SpatialAxis2D` of its own rather than sharing an enum with two members that would resolve to nothing.
+- Everything else — position, scale, velocity, transform point, both character readers, Can Fit — mirrors with the vector type swapped.
+
+## Related Docs
+
+- [Resolvers Reference](README.md)
+- [Spatial Nodes](../nodes/spatial-nodes.md) — the writing half of this family
+- [Physics Query Resolvers](physics-queries.md)
+- [Scene Graph and Interop Resolvers](scene-graph-resolvers.md)

--- a/docs/statescript/resolvers/spatial-getters.md
+++ b/docs/statescript/resolvers/spatial-getters.md
@@ -60,7 +60,7 @@ The `Only` variants are not redundant: a character wedged in a corner is on the 
 
 ## What differs in 2D
 
-- **`Entity Rotation 2D` reports a `float` in radians** rather than a quaternion, so core's whole numeric toolbox applies to a facing directly. **`Entity Angular Velocity 2D`** is likewise a `float` rate rather than an axis.
+- **`Entity Rotation 2D` reports a `float` in radians** rather than a quaternion, so core's whole numeric toolbox applies to a facing directly. **`Entity Angular Velocity 2D` reports a `double`** rate rather than an axis with a length.
 - **`Entity Direction 2D` offers four axes, not six.** A plane has no up and down of its own, and screen-up is already `Left` or `Right` of a facing, so it takes a `SpatialAxis2D` of its own rather than sharing an enum with two members that would resolve to nothing.
 - Everything else — position, scale, velocity, transform point, both character readers, Can Fit — mirrors with the vector type swapped.
 

--- a/docs/statescript/variables.md
+++ b/docs/statescript/variables.md
@@ -18,7 +18,9 @@ In the Godot editor, `Float` is the single designer-facing floating-point choice
 
 **Named integer values:** an `Int` value is often really a mode, a stance, or a state index. Define a [Statescript enum](enums.md) and author those values by name with the **Enum** resolver — the graph still stores a plain `int`, so nothing about the variable itself changes.
 
-**Reference (object-backed) types:** In addition to the value types above, the editor exposes object variable types for storing Forge reference objects. The built-in ones are `Entity`, `Effect`, and `Active Effect`. These have no inline initial value (they are assigned at runtime) and are read with the **Variable** resolver (or `ObjectVariableResolver<T>` in code).
+**Reference (object-backed) types:** In addition to the value types above, the editor exposes object variable types for storing reference objects. These have no inline initial value (they are assigned at runtime) and are read with the **Variable** resolver (or `ObjectVariableResolver<T>` in code).
+
+The core types are `Entity`, `Effect`, and `Active Effect`. Forge for Godot registers `Tag`, `Ability Handle` and `Ability Data` for the listener and grant nodes, and four engine types so a graph can hold what it spawned and what it queries with: `Node`, `Scene`, `Shape 3D` and `Shape 2D`. See [Object Variable Types](resolvers/README.md#object-variable-types) for what uses each.
 
 #### Adding a custom object variable type
 

--- a/docs/statescript/variables.md
+++ b/docs/statescript/variables.md
@@ -20,7 +20,7 @@ In the Godot editor, `Float` is the single designer-facing floating-point choice
 
 **Reference (object-backed) types:** In addition to the value types above, the editor exposes object variable types for storing reference objects. These have no inline initial value (they are assigned at runtime) and are read with the **Variable** resolver (or `ObjectVariableResolver<T>` in code).
 
-The core types are `Entity`, `Effect`, and `Active Effect`. Forge for Godot registers `Tag`, `Ability Handle` and `Ability Data` for the listener and grant nodes, and four engine types so a graph can hold what it spawned and what it queries with: `Node`, `Scene`, `Shape 3D` and `Shape 2D`. See [Object Variable Types](resolvers/README.md#object-variable-types) for what uses each.
+The core types are `Entity`, `Effect`, and `Active Effect`. Forge for Godot registers `Tag`, `Ability` (an `AbilityHandle`) and `Ability Data` for the listener and grant nodes, and four engine types so a graph can hold what it spawned and what it queries with: `Node`, `Scene`, `Shape 3D` and `Shape 2D`. See [Object Variable Types](resolvers/README.md#object-variable-types) for what uses each.
 
 #### Adding a custom object variable type
 


### PR DESCRIPTION
Added docs for the nodes, resolvers and handlers that we developed in the last few tasks.